### PR TITLE
Allow different validation error messages for each error-code

### DIFF
--- a/src/CodiceFiscaleServiceProvider.php
+++ b/src/CodiceFiscaleServiceProvider.php
@@ -52,10 +52,10 @@ class CodiceFiscaleServiceProvider extends ServiceProvider
                         $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.wrong_size'));
                         break;
                     case CodiceFiscaleValidationException::BAD_CHARACTERS:
-                        $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.wrong_size'));
+                        $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.bad_characters'));
                         break;
                     case CodiceFiscaleValidationException::BAD_OMOCODIA_CHAR:
-                        $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.wrong_size'));
+                        $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.bad_omocodia_char'));
                         break;
                     case CodiceFiscaleValidationException::WRONG_CODE:
                         $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.wrong_code'));


### PR DESCRIPTION
This PR adds the ability to specify a different error message using the validation rules for the following error codes: `bad_characters `and `bad_omocodia_char`