### PR TITLE
Allows Customizing The Validation Attributes

### DIFF
--- a/src/Validators/CodiceFiscaleValidator.php
+++ b/src/Validators/CodiceFiscaleValidator.php
@@ -54,28 +54,28 @@ class CodiceFiscaleValidator
         } catch (CodiceFiscaleValidationException $exception) {
             switch ($exception->getCode()) {
                 case CodiceFiscaleValidationException::NO_CODE:
-                    $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.no_code'));
+                    $error_msg = trans('validation.codice_fiscale.no_code', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
                     break;
                 case CodiceFiscaleValidationException::WRONG_SIZE:
-                    $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.wrong_size'));
+                    $error_msg = trans('validation.codice_fiscale.wrong_size', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
                     break;
                 case CodiceFiscaleValidationException::BAD_CHARACTERS:
-                    $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.bad_characters'));
+                    $error_msg = trans('validation.codice_fiscale.bad_characters', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
                     break;
                 case CodiceFiscaleValidationException::BAD_OMOCODIA_CHAR:
-                    $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.bad_omocodia_char'));
+                    $error_msg = trans('validation.codice_fiscale.bad_omocodia_char', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
                     break;
                 case CodiceFiscaleValidationException::WRONG_CODE:
-                    $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.wrong_code'));
+                    $error_msg = trans('validation.codice_fiscale.wrong_code', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
                     break;
                 case CodiceFiscaleValidationException::MISSING_CITY_CODE:
-                    $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.missing_city_code'));
+                    $error_msg = trans('validation.codice_fiscale.missing_city_code', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
                     break;
                 case CodiceFiscaleValidationException::NO_MATCH:
-                    $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.no_match'));
+                    $error_msg = trans('validation.codice_fiscale.no_match', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
                     break;
                 default:
-                    $error_msg = str_replace([':attribute'], [$attribute], trans('validation.codice_fiscale.wrong_code'));
+                    $error_msg = trans('validation.codice_fiscale.wrong_code', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
             }
 
             $validator->addReplacer('codice_fiscale', function ($message, $attribute, $rule, $parameters, $validator) use ($error_msg) {


### PR DESCRIPTION
## Description

This commit allows [Customizing The Validation Attributes](https://laravel.com/docs/9.x/validation#customizing-the-validation-attributes) and supports translated attribute names

## Motivation and context

Before this PR it was not possible to change the displayed name of the field when using the validator to validate an input field. The error message always showed the name of the input field, for example:
`The tax_number contains bad omocodia characters`
Now you can change the displayed name of the attribute and you can even translate it.
`The codice fiscale contains bad omocodia characters`

## How has this been tested?

using this code:
```php
/**
 * Get custom attributes for validator errors.
 *
 * @return array
 */
public function attributes()
{
    return [
        'tax_number' => 'codice fiscale',
    ];
}
```
i tried it using the validator, it successfully changed the name of the attribute as written above.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.