### PR TITLE
Prevent "Creation of dynamic property" (Deprecated on PHP 8.2)

### DIFF
--- a/src/CodiceFiscale.php
+++ b/src/CodiceFiscale.php
@@ -27,8 +27,6 @@ class CodiceFiscale
     private $birthPlace = null;
 
     private $day = null;
-
-    private $monthPart = null;
     
     private $month = null;
 
@@ -153,7 +151,6 @@ class CodiceFiscale
         $this->gender = null;
         $this->birthPlace = null;
         $this->day = null;
-        $this->monthPart = null;
         $this->month = null;
         $this->year = null;
         $this->error = null;
@@ -179,8 +176,8 @@ class CodiceFiscale
 
         $this->birthPlace = substr($adaptedCF, 11, 4);
         $this->year = substr($adaptedCF, 6, 2);
-        $this->monthPart = substr($adaptedCF, 8, 1);
-        $this->month = array_key_exists($this->monthPart, $this->tabDecodeMonths) ? $this->tabDecodeMonths[$this->monthPart] : null;
+        $monthPart = substr($adaptedCF, 8, 1);
+        $this->month = array_key_exists($monthPart, $this->tabDecodeMonths) ? $this->tabDecodeMonths[$monthPart] : null;
 
         $this->day = substr($adaptedCF, 9, 2);
 


### PR DESCRIPTION
Hello Roberto,

With the new changes I forgot to declare the "monthPart" variable and this generates a new alert:

> DEPRECATED  Creation of dynamic property robertogallea\LaravelCodiceFiscale\CodiceFiscale::$monthPart is deprecated in vendor/robertogallea/laravel-codicefiscale/src/CodiceFiscale.php on line 154.

I corrected and tested, thank you

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
