### PR TITLE
Added validation errors

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -9,4 +9,11 @@ return [
     'missing_city_code' => 'The :attribute contains a non-existing city code',
     'no_match'          => 'The :attribute does not match the given personal information',
     'empty_birthdate'  =>  'The :attribute cannot be validated against an invalid date of birth',
+    'wrong_first_name' => 'The digits in :attribute do not match the provided first name',
+    'wrong_last_name' => 'The digits in :attribute do not match the provided last name',
+    'wrong_birth_day' => 'The digits in :attribute do not match the provided birth day',
+    'wrong_birth_month' => 'The digits in :attribute do not match the provided birth month',
+    'wrong_birth_year' => 'The digits in :attribute do not match the provided birth year',
+    'wrong_birth_place' => 'The digits in :attribute do not match the provided birthplace',
+    'wrong_gender' => 'The digits in :attribute do not match the provided gender',
 ];

--- a/lang/it/validation.php
+++ b/lang/it/validation.php
@@ -9,4 +9,11 @@ return [
     'missing_city_code' => 'Il campo :attribute ha un codice del comune non corretto o non esistente',
     'no_match'          => 'Il campo :attribute non corrisponde ai dati inseriti',
     'empty_birthdate'  =>  'Il campo :attribute non può essere validato su una data di nascita non valida',
+    'wrong_first_name' => 'Le cifre nel :attribute non corrispondono al nome fornito',
+    'wrong_last_name' => 'Le cifre nel :attribute non corrispondono al cognome fornito',
+    'wrong_birth_day' => 'Le cifre nel :attribute non corrispondono al giorno di nascita fornito',
+    'wrong_birth_month' => 'Le cifre nel :attribute non corrispondono al mese di nascita fornito',
+    'wrong_birth_year' => 'Le cifre nel :attribute non corrispondono all\'anno di nascita fornito',
+    'wrong_birth_place' => 'Le cifre nel :attribute non corrispondono al città di nascita fornita',
+    'wrong_gender' => 'Le cifre nel :attribute non corrispondono al genere fornito',
 ];

--- a/src/Checks/CheckForOmocodiaChars.php
+++ b/src/Checks/CheckForOmocodiaChars.php
@@ -45,8 +45,10 @@ class CheckForOmocodiaChars implements Check
         $cfArray = str_split($code);
 
         for ($i = 0; $i < count($this->tabReplacementOmocodia); $i++) {
-            if ((! is_numeric($cfArray[$this->tabReplacementOmocodia[$i]])) &&
-                ($this->tabDecodeOmocodia[$cfArray[$this->tabReplacementOmocodia[$i]]] === '!')) {
+            if (
+                (! is_numeric($cfArray[$this->tabReplacementOmocodia[$i]])) &&
+                ($this->tabDecodeOmocodia[$cfArray[$this->tabReplacementOmocodia[$i]]] === '!')
+            ) {
                 throw new CodiceFiscaleValidationException(
                     'Invalid codice fiscale',
                     CodiceFiscaleValidationException::BAD_OMOCODIA_CHAR

--- a/src/CityCodeDecoders/ISTATRemoteCSVList.php
+++ b/src/CityCodeDecoders/ISTATRemoteCSVList.php
@@ -33,7 +33,7 @@ class ISTATRemoteCSVList implements CityDecoderInterface
 
     private static function str_replace_times($from, $to, $content, $times)
     {
-        $from = '/'.preg_quote($from, '/').'/';
+        $from = '/' . preg_quote($from, '/') . '/';
 
         return preg_replace($from, $to, $content, $times);
     }

--- a/src/CodiceFiscale.php
+++ b/src/CodiceFiscale.php
@@ -162,7 +162,7 @@ class CodiceFiscale
         $cfArray = str_split($cf);
 
         for ($i = 0; $i < count($this->tabReplacementOmocodia); $i++) {
-            if (! is_numeric($cfArray[$this->tabReplacementOmocodia[$i]])) {
+            if (!is_numeric($cfArray[$this->tabReplacementOmocodia[$i]])) {
                 $cfArray[$this->tabReplacementOmocodia[$i]] =
                     $this->tabDecodeOmocodia[$cfArray[$this->tabReplacementOmocodia[$i]]];
             }
@@ -184,7 +184,7 @@ class CodiceFiscale
         if ($this->gender === $this->config->getFemaleLabel()) {
             $this->day = $this->day - 40;
             if (strlen($this->day) === 1) {
-                $this->day = '0'.$this->day;
+                $this->day = '0' . $this->day;
             }
         }
 
@@ -217,7 +217,7 @@ class CodiceFiscale
             return;
         }
 
-        if (! array_key_exists($this->getBirthPlace(), $this->cityDecoder->getList())) {
+        if (!array_key_exists($this->getBirthPlace(), $this->cityDecoder->getList())) {
             throw new CodiceFiscaleValidationException(
                 'Invalid codice fiscale',
                 CodiceFiscaleValidationException::MISSING_CITY_CODE
@@ -230,7 +230,7 @@ class CodiceFiscale
     public function getBirthdate(): Carbon
     {
         try {
-            return Carbon::parse($this->getYear().'-'.$this->getMonth().'-'.$this->getDay());
+            return Carbon::parse($this->getYear() . '-' . $this->getMonth() . '-' . $this->getDay());
         } catch (\Exception $exception) {
             throw new CodiceFiscaleValidationException('Parsed date is not valid');
         }
@@ -240,10 +240,10 @@ class CodiceFiscale
     {
         $current_year = Carbon::today()->year;
         if (2000 + $this->year < $current_year) {
-            return '20'.$this->year;
+            return '20' . $this->year;
         }
 
-        return '19'.$this->year;
+        return '19' . $this->year;
     }
 
     public function getMonth()

--- a/src/CodiceFiscale.php
+++ b/src/CodiceFiscale.php
@@ -261,10 +261,20 @@ class CodiceFiscale
         return $this->cf;
     }
 
+    public function getFirstName()
+    {
+        return substr($this->cf, 3, 3);
+    }
+
+    public function getLastName()
+    {
+        return substr($this->cf, 0, 3);
+    }
+
     /**
+     * @return array
      * @throws CodiceFiscaleValidationException
      *
-     * @return array
      */
     public function asArray(): array
     {
@@ -276,6 +286,8 @@ class CodiceFiscale
             'month'                => $this->getMonth(),
             'year'                 => $this->getYear(),
             'birthdate'            => $this->getBirthdate(),
+            'first_name'           => $this->getFirstName(),
+            'last_name'            => $this->getLastName(),
         ];
     }
 }

--- a/src/CodiceFiscaleGenerator.php
+++ b/src/CodiceFiscaleGenerator.php
@@ -197,7 +197,7 @@ class CodiceFiscaleGenerator
         $gg = ($this->sesso == config('codicefiscale.labels.male')) ? $giorno : $giorno + 40;
         $gg = str_pad($gg, 2, '0', STR_PAD_LEFT);
 
-        return $aa.$mm.$gg;
+        return $aa . $mm . $gg;
     }
 
     protected function _calcolaCatastale()
@@ -230,13 +230,13 @@ class CodiceFiscaleGenerator
 
     public function calcola()
     {
-        $codice = $this->_calcolaCognome().
-            $this->_calcolaNome().
-            $this->_calcolaDataNascita().
+        $codice = $this->_calcolaCognome() .
+            $this->_calcolaNome() .
+            $this->_calcolaDataNascita() .
             $this->_calcolaCatastale();
         $codice .= $this->_calcolaCifraControllo($codice);
         if (strlen($codice) != 16) {
-            throw new CodiceFiscaleGenerationException('Generated code has not 16 digits: '.$codice);
+            throw new CodiceFiscaleGenerationException('Generated code has not 16 digits: ' . $codice);
         }
 
         return $codice;

--- a/src/CodiceFiscaleServiceProvider.php
+++ b/src/CodiceFiscaleServiceProvider.php
@@ -65,6 +65,6 @@ class CodiceFiscaleServiceProvider extends ServiceProvider
 
     private function packagePath($path)
     {
-        return __DIR__."/../$path";
+        return __DIR__ . "/../$path";
     }
 }

--- a/src/Exceptions/CodiceFiscaleValidationException.php
+++ b/src/Exceptions/CodiceFiscaleValidationException.php
@@ -21,4 +21,12 @@ class CodiceFiscaleValidationException extends \Exception
     public const NO_MATCH = 7;
 
     public const EMPTY_BIRTHDATE = 8;
+
+    public const WRONG_FIRST_NAME = 9;
+    public const WRONG_LAST_NAME = 10;
+    public const WRONG_BIRTH_DAY = 11;
+    public const WRONG_BIRTH_MONTH = 12;
+    public const WRONG_BIRTH_YEAR = 13;
+    public const WRONG_BIRTH_PLACE = 14;
+    public const WRONG_GENDER = 15;
 }

--- a/src/Validators/CodiceFiscaleValidator.php
+++ b/src/Validators/CodiceFiscaleValidator.php
@@ -17,18 +17,27 @@ class CodiceFiscaleValidator
 
     public function validate($attribute, $value, $parameters, $validator)
     {
+        $errorCodes = [
+            'first_name' => CodiceFiscaleValidationException::WRONG_FIRST_NAME,
+            'last_name' => CodiceFiscaleValidationException::WRONG_LAST_NAME,
+            'day' => CodiceFiscaleValidationException::WRONG_BIRTH_DAY,
+            'month' => CodiceFiscaleValidationException::WRONG_BIRTH_MONTH,
+            'year' => CodiceFiscaleValidationException::WRONG_BIRTH_YEAR,
+            'place' => CodiceFiscaleValidationException::WRONG_BIRTH_PLACE,
+            'gender' => CodiceFiscaleValidationException::WRONG_GENDER,
+        ];
+
         try {
             $this->codiceFiscale->parse($value);
-
             $data = $validator->getData();
 
             if (count($parameters)) {
                 $pieces = [
                     'first_name' => '',
-                    'last_name'  => '',
-                    'birthdate'  => '',
-                    'place'      => '',
-                    'gender'     => '',
+                    'last_name' => '',
+                    'birthdate' => '',
+                    'place' => '',
+                    'gender' => '',
                 ];
 
                 foreach ($parameters as $parameter) {
@@ -51,6 +60,15 @@ class CodiceFiscaleValidator
                 }
 
                 if ($value != $cf) {
+                    $newCodiceFiscale = new CodiceFiscale();
+                    $newCodiceFiscale->parse($cf);
+                    $this->compareAttribute('First Name', $newCodiceFiscale->getFirstName(), $this->codiceFiscale->getFirstName(), $errorCodes['first_name']);
+                    $this->compareAttribute('Last Name', $newCodiceFiscale->getLastName(), $this->codiceFiscale->getLastName(), $errorCodes['last_name']);
+                    $this->compareAttribute('Day', $newCodiceFiscale->getDay(), $this->codiceFiscale->getDay(), $errorCodes['day']);
+                    $this->compareAttribute('Month', $newCodiceFiscale->getMonth(), $this->codiceFiscale->getMonth(), $errorCodes['month']);
+                    $this->compareAttribute('Year', $newCodiceFiscale->getYear(), $this->codiceFiscale->getYear(), $errorCodes['year']);
+                    $this->compareAttribute('Birth Place', $newCodiceFiscale->getBirthPlace(), $this->codiceFiscale->getBirthPlace(), $errorCodes['place']);
+                    $this->compareAttribute('Gender', $newCodiceFiscale->getGender(), $this->codiceFiscale->getGender(), $errorCodes['gender']);
                     throw new CodiceFiscaleValidationException(
                         'Invalid codice fiscale',
                         CodiceFiscaleValidationException::NO_MATCH
@@ -83,6 +101,27 @@ class CodiceFiscaleValidator
                 case CodiceFiscaleValidationException::EMPTY_BIRTHDATE:
                     $error_msg = trans('codicefiscale::validation.empty_birthdate', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
                     break;
+                case CodiceFiscaleValidationException::WRONG_FIRST_NAME:
+                    $error_msg = trans('codicefiscale::validation.wrong_first_name', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
+                    break;
+                case CodiceFiscaleValidationException::WRONG_LAST_NAME:
+                    $error_msg = trans('codicefiscale::validation.wrong_last_name', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
+                    break;
+                case CodiceFiscaleValidationException::WRONG_BIRTH_DAY:
+                    $error_msg = trans('codicefiscale::validation.wrong_birth_day', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
+                    break;
+                case CodiceFiscaleValidationException::WRONG_BIRTH_MONTH:
+                    $error_msg = trans('codicefiscale::validation.wrong_birth_month', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
+                    break;
+                case CodiceFiscaleValidationException::WRONG_BIRTH_YEAR:
+                    $error_msg = trans('codicefiscale::validation.wrong_birth_year', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
+                    break;
+                case CodiceFiscaleValidationException::WRONG_BIRTH_PLACE:
+                    $error_msg = trans('codicefiscale::validation.wrong_birth_place', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
+                    break;
+                case CodiceFiscaleValidationException::WRONG_GENDER:
+                    $error_msg = trans('codicefiscale::validation.wrong_gender', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
+                    break;
                 default:
                     $error_msg = trans('codicefiscale::validation.wrong_code', ['attribute' => $validator->getDisplayableAttribute($attribute)]);
             }
@@ -95,5 +134,15 @@ class CodiceFiscaleValidator
         }
 
         return true;
+    }
+
+    function compareAttribute($attribute, $new, $old, $error)
+    {
+        if ($new != $old) {
+            throw new CodiceFiscaleValidationException(
+                "Invalid $attribute",
+                $error
+            );
+        }
     }
 }

--- a/tests/CodiceFiscaleConfigTest.php
+++ b/tests/CodiceFiscaleConfigTest.php
@@ -36,7 +36,7 @@ class CodiceFiscaleConfigTest extends TestCase
         $this->assertEquals($res[$cfPart], $cfValue);
     }
 
-    public function configChange()
+    public static function configChange()
     {
         return [
             ['RSSMRA95E05F205Z', 'codicefiscale.labels.male', 'male', 'male', 'gender'],

--- a/tests/CodiceFiscaleValidationTest.php
+++ b/tests/CodiceFiscaleValidationTest.php
@@ -86,7 +86,7 @@ class CodiceFiscaleValidationTest extends TestCase
         $this->assertEquals($res['birth_place_complete'], $city);
     }
 
-    public function omocodiaProvider()
+    public static function omocodiaProvider()
     {
         return [
             ['RSSMRA95E05F20RU', 'Milano'],

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -59,12 +59,12 @@ class ValidatorTest extends TestCase
         ];
 
         $data = [
-            'cf_field'   => 'RSSMRA80A01F205X',
+            'cf_field' => 'RSSMRA80A01F205X',
             'first_name' => 'Mario',
-            'last_name'  => 'Rossi',
-            'birthdate'  => '1980-01-01',
-            'place'      => 'Milano',
-            'gender'     => 'M',
+            'last_name' => 'Rossi',
+            'birthdate' => '1980-01-01',
+            'place' => 'Milano',
+            'gender' => 'M',
         ];
 
         $validator = $this->app['validator']->make($data, $rules);
@@ -79,12 +79,12 @@ class ValidatorTest extends TestCase
         ];
 
         $data = [
-            'cf_field'   => 'RSSMRA80A01F205X',
+            'cf_field' => 'RSSMRA80A01F205X',
             'first_name' => 'Mario',
-            'last_name'  => 'Rossi',
-            'birthdate'  => null,
-            'place'      => 'Milano',
-            'gender'     => 'M',
+            'last_name' => 'Rossi',
+            'birthdate' => null,
+            'place' => 'Milano',
+            'gender' => 'M',
         ];
 
         $validator = $this->app['validator']->make($data, $rules);
@@ -100,12 +100,12 @@ class ValidatorTest extends TestCase
         ];
 
         $data = [
-            'cf_field'   => 'RSSMRA80A01F205X',
+            'cf_field' => 'RSSMRA80A01F205X',
             'first_name' => 'Mario',
-            'last_name'  => 'Rossi',
-            'birthdate'  => '1980-01-01',
-            'place'      => 'PALERMO',
-            'gender'     => 'M',
+            'last_name' => 'Rossi',
+            'birthdate' => '1980-01-01',
+            'place' => 'PALERMO',
+            'gender' => 'M',
         ];
 
         $validator = $this->app['validator']->make($data, $rules);
@@ -121,11 +121,11 @@ class ValidatorTest extends TestCase
         ];
 
         $data = [
-            'cf_field'   => 'RSSMRA80A01F205X',
+            'cf_field' => 'RSSMRA80A01F205X',
             'first_name' => 'Mario',
-            'last_name'  => 'Rossi',
-            'birthdate'  => '1980-01-01',
-            'place'      => 'Milano',
+            'last_name' => 'Rossi',
+            'birthdate' => '1980-01-01',
+            'place' => 'Milano',
         ];
 
         $validator = $this->app['validator']->make($data, $rules);
@@ -152,6 +152,149 @@ class ValidatorTest extends TestCase
         $this->assertEquals(false, $validator->passes());
         $this->assertEquals(true, $validator->errors()->has('cf_field'));
     }
+
+    public function testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongFirstName()
+    {
+        $rules = [
+            'cf_field' => 'codice_fiscale:first_name=first_name,last_name=last_name,birthdate=birthdate,place=place,gender=gender',
+        ];
+        $data = [
+            'cf_field' => 'RSSMRA80A01F205X',
+            'first_name' => 'wrong_first_name',
+            'last_name' => 'Rossi',
+            'birthdate' => '1980-01-01',
+            'place' => 'Milano',
+            'gender' => 'M',
+        ];
+        $expectedErrorMessage  = trans('codicefiscale::validation.wrong_first_name', ['attribute' => "cf field"]);
+        $validator = $this->app['validator']->make($data, $rules);
+        $this->assertFalse($validator->passes());
+        $errorMessages = $validator->errors()->get('cf_field');
+        $this->assertSame($expectedErrorMessage, $errorMessages[0]);
+    }
+
+    public function testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongLastName()
+    {
+        $rules = [
+            'cf_field' => 'codice_fiscale:first_name=first_name,last_name=last_name,birthdate=birthdate,place=place,gender=gender',
+        ];
+        $data = [
+            'cf_field' => 'RSSMRA80A01F205X',
+            'first_name' => 'Mario',
+            'last_name' => 'wrong_last_name',
+            'birthdate' => '1980-01-01',
+            'place' => 'Milano',
+            'gender' => 'M',
+        ];
+        $expectedErrorMessage  = trans('codicefiscale::validation.wrong_last_name', ['attribute' => "cf field"]);
+        $validator = $this->app['validator']->make($data, $rules);
+        $this->assertFalse($validator->passes());
+        $errorMessages = $validator->errors()->get('cf_field');
+        $this->assertSame($expectedErrorMessage, $errorMessages[0]);
+    }
+
+
+    public function testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongBirthDay()
+    {
+        $rules = [
+            'cf_field' => 'codice_fiscale:first_name=first_name,last_name=last_name,birthdate=birthdate,place=place,gender=gender',
+        ];
+        $data = [
+            'cf_field' => 'RSSMRA80A01F205X',
+            'first_name' => 'Mario',
+            'last_name' => 'Rossi',
+            'birthdate' => '1980-01-08', //wrong day
+            'place' => 'Milano',
+            'gender' => 'M',
+        ];
+        $expectedErrorMessage  = trans('codicefiscale::validation.wrong_birth_day', ['attribute' => "cf field"]);
+        $validator = $this->app['validator']->make($data, $rules);
+        $this->assertFalse($validator->passes());
+        $errorMessages = $validator->errors()->get('cf_field');
+        $this->assertSame($expectedErrorMessage, $errorMessages[0]);
+    }
+
+    public function testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongBirthMonth()
+    {
+        $rules = [
+            'cf_field' => 'codice_fiscale:first_name=first_name,last_name=last_name,birthdate=birthdate,place=place,gender=gender',
+        ];
+        $data = [
+            'cf_field' => 'RSSMRA80A01F205X',
+            'first_name' => 'Mario',
+            'last_name' => 'Rossi',
+            'birthdate' => '1980-06-01', //wrong month
+            'place' => 'Milano',
+            'gender' => 'M',
+        ];
+        $expectedErrorMessage  = trans('codicefiscale::validation.wrong_birth_month', ['attribute' => "cf field"]);
+        $validator = $this->app['validator']->make($data, $rules);
+        $this->assertFalse($validator->passes());
+        $errorMessages = $validator->errors()->get('cf_field');
+        $this->assertSame($expectedErrorMessage, $errorMessages[0]);
+    }
+
+    public function testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongBirthYear()
+    {
+        $rules = [
+            'cf_field' => 'codice_fiscale:first_name=first_name,last_name=last_name,birthdate=birthdate,place=place,gender=gender',
+        ];
+        $data = [
+            'cf_field' => 'RSSMRA80A01F205X',
+            'first_name' => 'Mario',
+            'last_name' => 'Rossi',
+            'birthdate' => '1999-01-01', //wrong year
+            'place' => 'Milano',
+            'gender' => 'M',
+        ];
+        $expectedErrorMessage  = trans('codicefiscale::validation.wrong_birth_year', ['attribute' => "cf field"]);
+        $validator = $this->app['validator']->make($data, $rules);
+        $this->assertFalse($validator->passes());
+        $errorMessages = $validator->errors()->get('cf_field');
+        $this->assertSame($expectedErrorMessage, $errorMessages[0]);
+    }
+
+    public function testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongPlace()
+    {
+        $rules = [
+            'cf_field' => 'codice_fiscale:first_name=first_name,last_name=last_name,birthdate=birthdate,place=place,gender=gender',
+        ];
+        $data = [
+            'cf_field' => 'RSSMRA80A01F205X',
+            'first_name' => 'Mario',
+            'last_name' => 'Rossi',
+            'birthdate' => '1980-01-01',
+            'place' => 'Palermo',//wrong place
+            'gender' => 'M',
+        ];
+        $expectedErrorMessage  = trans('codicefiscale::validation.wrong_birth_place', ['attribute' => "cf field"]);
+        $validator = $this->app['validator']->make($data, $rules);
+        $this->assertFalse($validator->passes());
+        $errorMessages = $validator->errors()->get('cf_field');
+        $this->assertSame($expectedErrorMessage, $errorMessages[0]);
+    }
+
+    public function testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongGender()
+    {
+        $rules = [
+            'cf_field' => 'codice_fiscale:first_name=first_name,last_name=last_name,birthdate=birthdate,place=place,gender=gender',
+        ];
+        $data = [
+            'cf_field' => 'RSSMRA80A01F205X',
+            'first_name' => 'Mario',
+            'last_name' => 'Rossi',
+            'birthdate' => '1980-01-01',
+            'place' => 'Milano',
+            'gender' => 'wrong_gender', //wrong gender
+        ];
+        $expectedErrorMessage  = trans('codicefiscale::validation.wrong_gender', ['attribute' => "cf field"]);
+        $validator = $this->app['validator']->make($data, $rules);
+        $this->assertFalse($validator->passes());
+        $errorMessages = $validator->errors()->get('cf_field');
+        $this->assertSame($expectedErrorMessage, $errorMessages[0]);
+    }
+
+
 
     protected function getPackageProviders($app)
     {


### PR DESCRIPTION
## Description

Implemented distinct error codes and messages for validation errors related to missing first name, last name, date of birth, gender, and birthplace.

## Motivation and context

The application consistently returns an 'Invalid codice fiscale' without providing any information to the user about what might be wrong


## How has this been tested?

I have rigorously tested the changes by implementing the following test cases:

**testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongFirstName**: This test ensures that the validation process requires a correct Codice Fiscale against the corresponding form fields and fails when an incorrect first name is provided.

**testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongLastName**: This test verifies that the validation mechanism mandates a correct Codice Fiscale against the form fields and rejects submissions with an incorrect last name.

**testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongBirthDay**: The purpose of this test is to confirm that the validation process demands a correct Codice Fiscale in relation to the form fields and rejects submissions with an incorrect birth day.

**testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongBirthMonth**: This test ensures that the validation process necessitates a correct Codice Fiscale against the form fields and fails on submissions with an incorrect birth month.

**testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongBirthYear**: Verifying that the validation process mandates a correct Codice Fiscale against the form fields and rejects submissions with an incorrect birth year is the focus of this test.

**testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongPlace**: This test confirms that the validation process requires a correct Codice Fiscale against the form fields and fails when an incorrect place is provided.

**testValidationRequiresCorrectCfAgainstFormFieldsAndFailsOnWrongGender**: The purpose of this test is to ensure that the validation process demands a correct Codice Fiscale against the form fields and rejects submissions with an incorrect gender.

Each test case was executed in a controlled testing environment, and the overall impact of the changes on different areas of the code was thoroughly examined. The testing process aimed to validate the accuracy and robustness of the implemented changes.


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.
