### PR TITLE
Prevent code to break in production environment

### DIFF
--- a/src/CodiceFiscaleServiceProvider.php
+++ b/src/CodiceFiscaleServiceProvider.php
@@ -75,13 +75,17 @@ class CodiceFiscaleServiceProvider extends ServiceProvider
 
     public function registerFakerProvider(): void
     {
+        if(!class_exists(Factory::class)){
+            return;
+        }
+        
         $this->app->singleton(Generator::class, function () {
             $faker = Factory::create();
             $faker->addProvider(new CodiceFiscaleFakerProvider($faker));
 
             return $faker;
         });
-
+        
         fake()->addProvider(app(CodiceFiscaleFakerProvider::class));
     }
 }

--- a/src/CodiceFiscaleServiceProvider.php
+++ b/src/CodiceFiscaleServiceProvider.php
@@ -85,7 +85,9 @@ class CodiceFiscaleServiceProvider extends ServiceProvider
 
             return $faker;
         });
-        
-        fake()->addProvider(app(CodiceFiscaleFakerProvider::class));
+
+        if(function_exists('fake')){
+            fake()->addProvider(app(CodiceFiscaleFakerProvider::class));
+        }
     }
 }


### PR DESCRIPTION
Hi @robertogallea 

this commit (https://github.com/robertogallea/laravel-codicefiscale/commit/73dabd5b9dc6a4aad10c05f47df6021720fb6fa7) broke our application in production env, because `fake()` helper is not defined

I've just added the same check Laravel applies in helpers.php:462 before defining `fake()`:

```php
if (! function_exists('fake') && class_exists(\Faker\Factory::class)) {
    /**
     * Get a faker instance.
     *
     * @param  string|null  $locale
     * @return \Faker\Generator
     */
    function fake($locale = null)
    {
        if (app()->bound('config')) {
            $locale ??= app('config')->get('app.faker_locale');
        }

        $locale ??= 'en_US';

        $abstract = \Faker\Generator::class.':'.$locale;

        if (! app()->bound($abstract)) {
            app()->singleton($abstract, fn () => \Faker\Factory::create($locale));
        }

        return app()->make($abstract);
    }
}
```