### PR TITLE
Fix deprecated implicitly nullable parameter declarations for PHP 8.4…

### DIFF
--- a/src/CodiceFiscale.php
+++ b/src/CodiceFiscale.php
@@ -47,7 +47,7 @@ class CodiceFiscale
         CheckForWrongCode::class,
     ];
 
-    public function __construct(CityDecoderInterface $cityDecoder = null, CodiceFiscaleConfig $config = null)
+    public function __construct(?CityDecoderInterface $cityDecoder = null, ?CodiceFiscaleConfig $config = null)
     {
         $this->config = $config ?? resolve(CodiceFiscaleConfig::class);
 
@@ -100,7 +100,7 @@ class CodiceFiscale
         ];
     }
 
-    public static function generate(string $first_name, string $last_name, Carbon|string $birth_date, string $place, string $gender, CodiceFiscaleConfig $config = null): string
+    public static function generate(string $first_name, string $last_name, Carbon|string $birth_date, string $place, string $gender, ?CodiceFiscaleConfig $config = null): string
     {
         $config = $config ?: resolve(CodiceFiscaleConfig::class);
 


### PR DESCRIPTION
The recent PHP 8.4 update [deprecated implicity nullable parameter declarionts](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated).
As recommended, this simple PR changes the implicit nullable type declarations to nullable type declarations.

Support for nullable types was introduced in [7.1](https://wiki.php.net/rfc/nullable_types).

EDIT: typos and punctuation.


## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/9558c59f-4f7d-4e23-bcce-097d86bad885)

![image](https://github.com/user-attachments/assets/2e8ccf09-135e-4a08-8540-165c3b8d7db1)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!