### PR TITLE
Fix name/surname code generation padding with X 

### DIFF
--- a/src/CodiceFiscaleGenerator.php
+++ b/src/CodiceFiscaleGenerator.php
@@ -113,9 +113,6 @@ class CodiceFiscaleGenerator
         }
         $nome = $this->_pulisci($this->nome);
 
-        if (strlen($nome) < 3) {
-            return $this->_aggiungiX($nome);
-        }
         $nome_cons = $this->_trovaConsonanti($nome);
 
         if (count($nome_cons) <= 3) {
@@ -133,9 +130,13 @@ class CodiceFiscaleGenerator
 
         if (strlen($code) < 3) {
             $nome_voc = $this->_trovaVocali($nome);
-            while (strlen($code) < 3) {
+            while (strlen($code) < 3 && count($nome_voc) > 0) {
                 $code .= array_shift($nome_voc);
             }
+        }
+
+        if (strlen($code) < 3) {
+            $code = $this->_aggiungiX($code);
         }
 
         return $code;
@@ -148,9 +149,6 @@ class CodiceFiscaleGenerator
         }
         $cognome = $this->_pulisci($this->cognome);
 
-        if (strlen($cognome) < 3) {
-            return $this->_aggiungiX($cognome);
-        }
         $cognome_cons = $this->_trovaConsonanti($cognome);
 
         $code = '';
@@ -162,9 +160,13 @@ class CodiceFiscaleGenerator
 
         if (strlen($code) < 3) {
             $cognome_voc = $this->_trovaVocali($cognome);
-            while (strlen($code) < 3) {
+            while (strlen($code) < 3 && count($cognome_voc) > 0) {
                 $code .= array_shift($cognome_voc);
             }
+        }
+
+        if (strlen($code) < 3) {
+            $code = $this->_aggiungiX($code);
         }
 
         return $code;

--- a/tests/CodiceFiscaleGenerationTest.php
+++ b/tests/CodiceFiscaleGenerationTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use robertogallea\LaravelCodiceFiscale\CodiceFiscale;
 use robertogallea\LaravelCodiceFiscale\Exceptions\CodiceFiscaleGenerationException;
 use TypeError;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CodiceFiscaleGenerationTest extends TestCase
 {
@@ -108,7 +109,7 @@ class CodiceFiscaleGenerationTest extends TestCase
         $first_name = 'Mario';
         $last_name = 'Rossi';
         $birth_date = '1995-05-05';
-        $birth_place = 'F205';
+        $birth_place = 'Milano';
         $gender = 'M';
 
         $res = CodiceFiscale::generate($first_name, $last_name, $birth_date, $birth_place, $gender);
@@ -226,6 +227,32 @@ class CodiceFiscaleGenerationTest extends TestCase
     {
         return [
             \robertogallea\LaravelCodiceFiscale\CodiceFiscaleServiceProvider::class,
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('nameSurnameBlocksProvider')]
+    public function it_generates_correct_name_and_surname_blocks(string $firstName, string $lastName, Carbon $birthDate, string $expectedCf): void
+    {
+        $birth_place = 'F205'; // Milano
+        $gender = 'M';
+
+        $res = CodiceFiscale::generate($firstName, $lastName, $birthDate, $birth_place, $gender);
+
+        $this->assertEquals($expectedCf, $res);
+    }
+
+    public static function nameSurnameBlocksProvider(): array
+    {
+        return [
+            // ASH -> SHA, OS -> SOX
+            ['ASH', 'OS', Carbon::parse('1990-01-01'), 'SOXSHA90A01F205B'],
+            // MARIO -> MRA, OM -> MOX
+            ['MARIO', 'OM', Carbon::parse('1990-01-01'), 'MOXMRA90A01F205S'],
+            // IO -> IOX, ROSSI -> RSS
+            ['IO', 'ROSSI', Carbon::parse('1990-01-01'), 'RSSIOX90A01F205V'],
+            // nome corto: MA -> MAX
+            ['Ma', 'Rossi', Carbon::parse('1995-05-05'), 'RSSMAX95E05F205P'],
         ];
     }
 }


### PR DESCRIPTION
### Summary
This PR fixes the generation of the 3-character blocks for **first name** and **last name** in the Italian *Codice Fiscale* algorithm.

Previously, when the input name/surname length was `< 3`, the implementation returned early and padded the raw cleaned string with `X`. That behavior is incorrect according to the official rules: the algorithm must **first build the code using consonants and then vowels**, and **only after that** pad with `X` if still shorter than 3 characters.

### Examples
- `OM` → consonants: `M`, vowels: `O` → `MOX`
- `IO` → vowels only → `IOX`
- `CRISTINA` (4+ consonants) → consonants: `C R S T ...` → `CST`

### Checklist
- [X] Code follows existing style conventions  
- [X] Verified generated CF matches expected rules for edge cases