### PR TITLE
Add v3 domain model, ADRs, and agent-tooling config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Project
+
+`robertogallea/laravel-codicefiscale` — Italian codice fiscale (tax code) parsing, generation, and validation for Laravel. Currently on the 2.x line; a 3.x rewrite is being designed (see `CONTEXT.md` and `docs/adr/`).
+
+## Conventions
+
+- PHP ^8.2, PSR-4 autoloading under `src/`.
+- Tests: PHPUnit today; new 3.x tests are written in Pest (see `docs/adr/` for the reasoning split).
+- Style: enforced via `.php-cs-fixer.php`; run before committing.
+- Read `CONTEXT.md` and relevant `docs/adr/*.md` before making domain-level changes — see `docs/agents/domain.md` for the full consumer rules.
+- Commit messages never mention authors — no `Co-Authored-By:` trailers or similar attribution lines.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live on GitHub (`robertogallea/laravel-codicefiscale`), via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles map mostly onto new labels, reusing `question` for needs-info and `wontfix` as-is. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,27 @@
+# Laravel Codice Fiscale
+
+Domain model for the 3.x rewrite of the Italian *codice fiscale* (tax code) parsing, generation, and validation package.
+
+## Language
+
+**BirthPlaceCode**:
+The 4-character cadastral code embedded in a codice fiscale's positions 12-15 (e.g. `H501` for Roma). Assigned by the Italian tax authority; distinct from — and never equal to — the ISTAT code.
+_Avoid_: place code, city code, comune code
+
+**BirthPlace**:
+A single time-bounded record describing a `BirthPlaceCode` during one era: name, province, ISTAT code, and the `[validFrom, validTo)` window during which that name/province combination held. A municipality that renamed or changed province produces multiple `BirthPlace` records sharing the same `BirthPlaceCode`, one per era.
+_Avoid_: City, Municipality, Comune (as the class/API name — "comune" is fine in prose)
+
+**Domestic birthplace**:
+A `BirthPlace` for an Italian comune, sourced from ANPR's comuni archive. Has a real `[validFrom, validTo)` history, a province, and an ISTAT code.
+
+**Omocodia**:
+The condition where a computed codice fiscale collides with one already assigned to someone else, resolved by substituting a subset of 7 fixed digit positions (year digits, day digits, birthplace-code digits) with corresponding letters via a fixed digit→letter map, then recomputing the check character. Any of the 2⁷ = 128 subsets of those 7 positions may be substituted independently — omocodia is a per-position combination, not a cumulative single-dimension "level."
+_Avoid_: homograph
+
+**Canonical form**:
+The one member of a person's 128 possible codice fiscali where none of the 7 omocodia-sensitive positions are letter-substituted. Reversing substitutions back to digits is a pure mechanical transform on the string itself — it needs no repository or generator.
+_Avoid_: original code, base code
+
+**Foreign birthplace**:
+A `BirthPlace` for a country (`Z`-prefixed `BirthPlaceCode`), sourced from MAECI's stati-esteri table. Has an ISO 3166-1 alpha-3 code and no province; its `[validFrom, validTo)` is currently always maximally wide because the source table carries no genuine historical data — a country whose meaning changed over time (e.g. a code that once denoted one state and now denotes its successor) is not distinguishable by date in 3.0.

--- a/docs/adr/0001-clean-break-from-2x-api.md
+++ b/docs/adr/0001-clean-break-from-2x-api.md
@@ -1,0 +1,5 @@
+# Clean break from the 2.x API for 3.0
+
+2.x's `CodiceFiscale` mixes mutable parsing state, validation, and generation behind one class; 3.x replaces it with an immutable value object plus separate `Parser`/`Generator`/`Validator`/`Matcher` services. 3.0 makes no attempt to preserve or shim the 2.x API (`new CodiceFiscale()`, `->parse()`, `::generate()`, `->getError()`, `->getFirstName()`/`->getLastName()`) — migration is documented in `UPGRADE.md` only.
+
+A stateful, mutable 2.x API cannot be honestly wrapped around an immutable value-object core without compromising the new design; a clear migration table is more honest than a shim that only half-works.

--- a/docs/adr/0002-framework-agnostic-core-namespace.md
+++ b/docs/adr/0002-framework-agnostic-core-namespace.md
@@ -1,0 +1,5 @@
+# Core is framework-agnostic; Laravel integration lives in its own namespace within the same package
+
+The 2.x package mixes Laravel-specific concerns (service container resolution, config) directly into the core CF logic, under the namespace `robertogallea\LaravelCodiceFiscale\`. 3.0 moves the framework-agnostic core to `Robertogallea\CodiceFiscale\...`, with all Laravel-specific classes (service provider, Eloquent models/repositories, validation rule, cast, artisan commands) under `Robertogallea\CodiceFiscale\Laravel\...`. The package stays a single Composer package for 3.0; splitting core/data/Laravel into separate packages is deferred until the API stabilizes.
+
+This enforces "Core knows nothing about Laravel; Laravel knows about Core" as an actual dependency-direction constraint, not just a stated principle, while a single package avoids premature multi-package coordination overhead.

--- a/docs/adr/0003-no-bundled-birthplace-data.md
+++ b/docs/adr/0003-no-bundled-birthplace-data.md
@@ -1,0 +1,7 @@
+# Birthplace reference data is never bundled in the package; it's downloaded on demand
+
+The richer `BirthPlace` model (municipality/country history) needs ANPR's comuni archive and MAECI's stati-esteri table. Neither source states an explicit redistribution license. The package ships no committed snapshot of this data — a `codice-fiscale:update-places` artisan command downloads both sources directly into the consuming application's own storage (SQLite file), on demand.
+
+Bundling a converted copy of government data with unclear redistribution terms into every Packagist release would be redistributing it under our own unverified authority; having each installation fetch its own copy sidesteps that risk entirely, at the cost of a one-time setup step per install.
+
+**Considered options**: Bundle a snapshot anyway, accepting the licensing ambiguity — rejected because it's an unnecessary and easily-avoided risk for a public open-source package.

--- a/docs/adr/0004-eloquent-repository-confined-to-laravel-layer.md
+++ b/docs/adr/0004-eloquent-repository-confined-to-laravel-layer.md
@@ -1,0 +1,5 @@
+# BirthPlaceRepository's reference implementation is Eloquent-backed and lives only in the Laravel layer
+
+The repository needs to answer validity-window queries ("was this code valid on this date") efficiently against ~20k historical rows. Core defines the `BirthPlaceRepository` contract and plain DTOs only. The Laravel layer provides `EloquentBirthPlaceRepository`, backed by two Eloquent models (`Municipality`, `ForeignCountry`) on a dedicated SQLite connection that the service provider registers at runtime — never the consuming app's primary database connection or migrations.
+
+This preserves ADR-0002's Core/Laravel boundary while still using Eloquent's query builder for what are naturally range queries; an isolated connection means installing this package never touches the host application's own schema.

--- a/docs/adr/0005-two-birthplace-tables.md
+++ b/docs/adr/0005-two-birthplace-tables.md
@@ -1,0 +1,5 @@
+# Municipality and country records are two separate tables, not one wide table
+
+Domestic (Italian) birthplace records carry province/ISTAT-code/real validity history from ANPR; foreign records carry an ISO 3166-1 alpha-3 code and no real history, from MAECI — different shapes, different source files, different update cadence. 3.0 uses two Eloquent models/tables (`Municipality`, `ForeignCountry`), unified behind one `CompositeBirthPlaceRepository`, mapping to two DTOs (`DomesticBirthPlace`, `ForeignBirthPlace`) that implement a shared `BirthPlace` interface.
+
+A single wide table would null out half its columns depending on domestic vs. foreign; two focused tables map directly onto the two focused source files and avoid modeling a field (`country`) that's meaningless for the majority (domestic) case.

--- a/docs/adr/0006-default-century-resolver.md
+++ b/docs/adr/0006-default-century-resolver.md
@@ -1,0 +1,5 @@
+# Century ambiguity gets a built-in default resolver instead of forcing every caller to supply one
+
+A codice fiscale's two-digit birth year is inherently ambiguous (e.g. `26` could mean 1926 or 2026); 2.x resolved this with a heuristic it itself acknowledged as broken. `Parser::parse()` applies `AgeBasedCenturyResolver(maxAge: 120)` automatically when no explicit `CenturyResolver` is supplied, while still exposing `possibleBirthYears()` and accepting a swappable resolver for callers who need different behavior.
+
+Most callers just want a birthdate and shouldn't be forced to reason about omocodia-era ambiguity on day one; a documented, swappable default is more honest than either silently guessing (2.x) or refusing to resolve at all.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| --------------------------- | --------------------- | ----------------------------------------- |
+| `needs-triage`               | `needs-triage`         | Maintainer needs to evaluate this issue  |
+| `needs-info`                 | `question`             | Waiting on reporter for more information |
+| `ready-for-agent`            | `ready-for-agent`      | Fully specified, ready for an AFK agent  |
+| `ready-for-human`            | `ready-for-human`      | Requires human implementation            |
+| `wontfix`                    | `wontfix`              | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+`needs-info` and `wontfix` reuse this repo's existing general-purpose labels (`question`, `wontfix`); `needs-triage`, `ready-for-agent`, and `ready-for-human` are new labels created specifically for this vocabulary.


### PR DESCRIPTION
## Summary
- Domain glossary (`CONTEXT.md`) and six ADRs (`docs/adr/`) from the v3 rewrite design session, referenced by spec #75 and tickets #76-#89.
- Agent-tooling config (`AGENTS.md`, symlinked `CLAUDE.md`, `docs/agents/`) so the engineering skills know where issues/labels/domain docs live for this repo.

No implementation code — planning artifacts only.