### PR TITLE
CodiceFiscale value object + Checksum service

### DIFF
--- a/src/CodiceFiscale.php
+++ b/src/CodiceFiscale.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale;
+
+use Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException;
+
+final class CodiceFiscale implements \Stringable
+{
+    /**
+     * Structural shape of a codice fiscale: 3 surname-code letters, 3
+     * name-code letters, 2 year digits (or omocodia letters), 1 month
+     * letter, 2 day digits (or omocodia letters), 1 birthplace-code
+     * prefix letter, 3 birthplace-code digits (or omocodia letters),
+     * 1 check-character letter. Omocodia substitution only ever
+     * replaces a digit with one of L,M,N,P,Q,R,S,T,U,V.
+     */
+    private const STRUCTURE_PATTERN =
+        '/^[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]$/';
+
+    private function __construct(
+        private readonly string $value,
+    ) {
+    }
+
+    public static function from(string $value): self
+    {
+        return self::tryFrom($value) ?? throw new InvalidCodiceFiscaleException(
+            sprintf('"%s" is not a structurally valid codice fiscale.', $value)
+        );
+    }
+
+    public static function tryFrom(string $value): ?self
+    {
+        $normalized = strtoupper(trim($value));
+
+        if (preg_match(self::STRUCTURE_PATTERN, $normalized) !== 1) {
+            return null;
+        }
+
+        return new self($normalized);
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/CodiceFiscale.php
+++ b/src/CodiceFiscale.php
@@ -12,7 +12,10 @@ final class CodiceFiscale implements \Stringable
      * letter, 2 day digits (or omocodia letters), 1 birthplace-code
      * prefix letter, 3 birthplace-code digits (or omocodia letters),
      * 1 check-character letter. Omocodia substitution only ever
-     * replaces a digit with one of L,M,N,P,Q,R,S,T,U,V.
+     * replaces a digit with one of L,M,N,P,Q,R,S,T,U,V. The month
+     * letter is restricted to A,B,C,D,E,H,L,M,P,R,S,T (January
+     * through December, in that order) — no other letter is valid
+     * in that position.
      */
     private const STRUCTURE_PATTERN =
         '/^[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]$/';

--- a/src/Exceptions/InvalidCodiceFiscaleException.php
+++ b/src/Exceptions/InvalidCodiceFiscaleException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Exceptions;
+
+class InvalidCodiceFiscaleException extends \InvalidArgumentException
+{
+}

--- a/src/Generation/Checksum.php
+++ b/src/Generation/Checksum.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Generation;
+
+final class Checksum
+{
+    private const ODD_POSITION_VALUES = [
+        '0' => 1, '1' => 0, '2' => 5, '3' => 7, '4' => 9,
+        '5' => 13, '6' => 15, '7' => 17, '8' => 19, '9' => 21,
+        'A' => 1, 'B' => 0, 'C' => 5, 'D' => 7, 'E' => 9,
+        'F' => 13, 'G' => 15, 'H' => 17, 'I' => 19, 'J' => 21,
+        'K' => 2, 'L' => 4, 'M' => 18, 'N' => 20, 'O' => 11,
+        'P' => 3, 'Q' => 6, 'R' => 8, 'S' => 12, 'T' => 14,
+        'U' => 16, 'V' => 10, 'W' => 22, 'X' => 25, 'Y' => 24, 'Z' => 23,
+    ];
+
+    private const EVEN_POSITION_VALUES = [
+        '0' => 0, '1' => 1, '2' => 2, '3' => 3, '4' => 4,
+        '5' => 5, '6' => 6, '7' => 7, '8' => 8, '9' => 9,
+        'A' => 0, 'B' => 1, 'C' => 2, 'D' => 3, 'E' => 4,
+        'F' => 5, 'G' => 6, 'H' => 7, 'I' => 8, 'J' => 9,
+        'K' => 10, 'L' => 11, 'M' => 12, 'N' => 13, 'O' => 14,
+        'P' => 15, 'Q' => 16, 'R' => 17, 'S' => 18, 'T' => 19,
+        'U' => 20, 'V' => 21, 'W' => 22, 'X' => 23, 'Y' => 24, 'Z' => 25,
+    ];
+
+    private const CHECK_CHARACTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    public function calculate(string $first15Characters): string
+    {
+        $sum = 0;
+
+        foreach (str_split($first15Characters) as $index => $character) {
+            $position = $index + 1;
+            $sum += $position % 2 !== 0
+                ? self::ODD_POSITION_VALUES[$character]
+                : self::EVEN_POSITION_VALUES[$character];
+        }
+
+        return self::CHECK_CHARACTERS[$sum % 26];
+    }
+
+    public function verify(string $fullCode): bool
+    {
+        return $this->calculate(substr($fullCode, 0, 15)) === substr($fullCode, 15, 1);
+    }
+}

--- a/tests/Unit/ChecksumTest.php
+++ b/tests/Unit/ChecksumTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Generation\Checksum;
+
+test('calculates the known check character for a canonical code', function () {
+    expect((new Checksum())->calculate('RSSMRA95E05F205'))->toBe('Z');
+});
+
+test('calculates the known check character for other real fixtures', function (string $first15, string $expectedCheckCharacter) {
+    expect((new Checksum())->calculate($first15))->toBe($expectedCheckCharacter);
+})->with([
+    'omocodia variant (day substituted)' => ['RSSMRA95E05F20R', 'U'],
+    'omocodia variant (multiple positions substituted)' => ['MKJRLA80A01L4L7', 'I'],
+    'female code (day + 40)' => ['RSSMRA95E45F205', 'D'],
+    'international birthplace' => ['RBRRHR93L09Z357', 'P'],
+    'short name padded with X' => ['RSSMAX95E05F205', 'P'],
+]);
+
+test('verify confirms a correct check character and rejects an incorrect one', function () {
+    $checksum = new Checksum();
+
+    expect($checksum->verify('RSSMRA95E05F205Z'))->toBeTrue()
+        ->and($checksum->verify('RSSMRA95E05F205A'))->toBeFalse();
+});

--- a/tests/Unit/CodiceFiscaleTest.php
+++ b/tests/Unit/CodiceFiscaleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException;
+
+test('from() constructs a value object exposing the given code', function () {
+    $cf = CodiceFiscale::from('RSSMRA95E05F205Z');
+
+    expect($cf->value())->toBe('RSSMRA95E05F205Z');
+});
+
+test('from() accepts other structurally well-formed real fixtures', function (string $code) {
+    expect(CodiceFiscale::from($code)->value())->toBe($code);
+})->with([
+    'omocodia variant' => ['RSSMRA95E05F20RU'],
+    'omocodia variant, multiple positions substituted' => ['MKJRLA80A01L4L7I'],
+    'female code (day + 40)' => ['RSSMRA95E45F205D'],
+    'international birthplace' => ['RBRRHR93L09Z357P'],
+    'wrong checksum, still structurally fine' => ['RSSMRA95E05F205A'],
+    'nonsense birthplace code, still structurally fine' => ['LNEGLI94D20A000X'],
+    'nonexistent date (day 77), still structurally fine' => ['LOIMLC71A77F979V'],
+]);
+
+test('from() normalizes lowercase input', function () {
+    expect(CodiceFiscale::from('rssmra95e05f205z')->value())->toBe('RSSMRA95E05F205Z');
+});
+
+test('from() throws for malformed input', function (string $code) {
+    expect(fn () => CodiceFiscale::from($code))->toThrow(InvalidCodiceFiscaleException::class);
+})->with([
+    'too short' => ['ABC'],
+    'too long' => ['ABCDEF01G23H456IX'],
+    'contains a non-alphanumeric character' => ['%SSMRA95E05F20RU'],
+    'invalid omocodia character (O is not a valid substitution letter)' => ['RSSMRA95E05F20OU'],
+    'invalid month letter' => ['RSSMRA95Z05F205Z'],
+]);
+
+test('tryFrom() returns null for the same malformed input instead of throwing', function (string $code) {
+    expect(CodiceFiscale::tryFrom($code))->toBeNull();
+})->with([
+    'too short' => ['ABC'],
+    'contains a non-alphanumeric character' => ['%SSMRA95E05F20RU'],
+    'invalid omocodia character' => ['RSSMRA95E05F20OU'],
+]);
+
+test('has no dependency on checksum validity', function () {
+    // RSSMRA95E05F205A has an incorrect check character (the real one is Z),
+    // yet construction succeeds — checksum correctness is exclusively the
+    // Validator's concern, not the value object's.
+    expect(fn () => CodiceFiscale::from('RSSMRA95E05F205A'))->not->toThrow(Throwable::class);
+});
+
+test('casts to string as its value', function () {
+    $cf = CodiceFiscale::from('RSSMRA95E05F205Z');
+
+    expect((string) $cf)->toBe('RSSMRA95E05F205Z');
+});

--- a/tests/Unit/CodiceFiscaleTest.php
+++ b/tests/Unit/CodiceFiscaleTest.php
@@ -39,8 +39,10 @@ test('tryFrom() returns null for the same malformed input instead of throwing', 
     expect(CodiceFiscale::tryFrom($code))->toBeNull();
 })->with([
     'too short' => ['ABC'],
+    'too long' => ['ABCDEF01G23H456IX'],
     'contains a non-alphanumeric character' => ['%SSMRA95E05F20RU'],
     'invalid omocodia character' => ['RSSMRA95E05F20OU'],
+    'invalid month letter' => ['RSSMRA95Z05F205Z'],
 ]);
 
 test('has no dependency on checksum validity', function () {


### PR DESCRIPTION
Closes #77.

Stacked on #91 (branches off `feature/76-project-scaffolding`, since this ticket is blocked by #76 which isn't merged yet) — review the diff against that branch, not master.

## Summary
- `CodiceFiscale::from()`/`tryFrom()`: immutable value object enforcing structural well-formedness only (16 characters, correct character class per position, including the omocodia-eligible positions) — checksum and semantic correctness are explicitly out of scope, reserved for the `Validator` in a later ticket.
- `Checksum::calculate()`/`verify()`: extracted check-digit algorithm, ported from the 2.x generator's odd/even conversion tables.
- Test fixtures reused from the deleted 2.x test suite (recovered via `git show`) rather than invented, per the acceptance criteria.

## Test plan
- [x] 29 Pest tests passing, including real fixtures for omocodia variants, female codes, international birthplaces, and structurally-fine-but-semantically-wrong cases (bad checksum, nonsense birthplace, invalid date)
- [x] PHPStan level max passes clean
- [x] `php-cs-fixer --dry-run` passes
- [x] Reviewed via `/code-review` (Standards + Spec axes) — two fixes applied (documented the month-letter character class, extended `tryFrom()`'s test dataset to match `from()`'s for full parity coverage)