### PR TITLE
BirthPlace domain contracts + in-memory test repository

### DIFF
--- a/src/Contracts/BirthPlace.php
+++ b/src/Contracts/BirthPlace.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Contracts;
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+
+/**
+ * A single time-bounded record describing a BirthPlaceCode during one
+ * era: name and the [validFrom, validTo) window during which that
+ * name (and, for a domestic record, province) combination held.
+ * validTo() is null for a still-currently-valid record.
+ */
+interface BirthPlace
+{
+    public function code(): BirthPlaceCode;
+
+    public function name(): string;
+
+    public function validFrom(): \DateTimeImmutable;
+
+    public function validTo(): ?\DateTimeImmutable;
+
+    public function wasValidOn(\DateTimeImmutable $date): bool;
+}

--- a/src/Contracts/BirthPlaceRepository.php
+++ b/src/Contracts/BirthPlaceRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Contracts;
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+
+interface BirthPlaceRepository
+{
+    /**
+     * The era-record valid on the given date (defaulting to today),
+     * or null if the code isn't recognized at all, or is recognized
+     * but wasn't valid on that date.
+     */
+    public function find(BirthPlaceCode $code, ?\DateTimeImmutable $on = null): ?BirthPlace;
+
+    /**
+     * Whether this code was ever valid, at any point in its history -
+     * distinguishes "never a valid code" from "valid code, wrong date".
+     */
+    public function existedEver(BirthPlaceCode $code): bool;
+}

--- a/src/Data/AbstractBirthPlace.php
+++ b/src/Data/AbstractBirthPlace.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Data;
+
+use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
+
+/**
+ * Shared [validFrom, validTo) bookkeeping for DomesticBirthPlace and
+ * ForeignBirthPlace. Holds only what both eras genuinely have in
+ * common — a province/istatCode/country field does not belong here,
+ * since that split is exactly what distinguishes the two subtypes.
+ */
+abstract readonly class AbstractBirthPlace implements BirthPlace
+{
+    public function __construct(
+        private BirthPlaceCode $code,
+        private string $name,
+        private \DateTimeImmutable $validFrom,
+        private ?\DateTimeImmutable $validTo = null,
+    ) {
+    }
+
+    public function code(): BirthPlaceCode
+    {
+        return $this->code;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function validFrom(): \DateTimeImmutable
+    {
+        return $this->validFrom;
+    }
+
+    public function validTo(): ?\DateTimeImmutable
+    {
+        return $this->validTo;
+    }
+
+    public function wasValidOn(\DateTimeImmutable $date): bool
+    {
+        return $date >= $this->validFrom
+            && ($this->validTo === null || $date < $this->validTo);
+    }
+}

--- a/src/Data/AbstractValidatedCode.php
+++ b/src/Data/AbstractValidatedCode.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Data;
+
+/**
+ * Shared shape for a short, pattern-validated code: normalize
+ * (uppercase, trim), match against a fixed regex, or fail. Used by
+ * BirthPlaceCode and CountryCode, which differ only in their pattern
+ * and the exception they throw.
+ *
+ * @phpstan-consistent-constructor
+ */
+abstract class AbstractValidatedCode implements \Stringable
+{
+    protected function __construct(
+        private readonly string $value,
+    ) {
+    }
+
+    abstract protected static function pattern(): string;
+
+    /** @return class-string<\InvalidArgumentException> */
+    abstract protected static function exceptionClass(): string;
+
+    public static function from(string $value): static
+    {
+        return static::tryFrom($value) ?? throw new (static::exceptionClass())(
+            sprintf('"%s" is not a valid %s.', $value, static::class)
+        );
+    }
+
+    public static function tryFrom(string $value): ?static
+    {
+        $normalized = strtoupper(trim($value));
+
+        if (preg_match(static::pattern(), $normalized) !== 1) {
+            return null;
+        }
+
+        return new static($normalized);
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/BirthPlaceCode.php
+++ b/src/Data/BirthPlaceCode.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Data;
+
+use Robertogallea\CodiceFiscale\Exceptions\InvalidBirthPlaceCodeException;
+
+/**
+ * The 4-character cadastral code embedded in a codice fiscale's
+ * positions 12-15 (e.g. "H501" for Roma, "Z404" for the USA).
+ * Distinct from, and never equal to, an ISTAT code.
+ */
+final class BirthPlaceCode implements \Stringable
+{
+    private const PATTERN = '/^[A-Z][0-9]{3}$/';
+
+    private function __construct(
+        private readonly string $value,
+    ) {
+    }
+
+    public static function from(string $value): self
+    {
+        return self::tryFrom($value) ?? throw new InvalidBirthPlaceCodeException(
+            sprintf('"%s" is not a structurally valid birthplace code.', $value)
+        );
+    }
+
+    public static function tryFrom(string $value): ?self
+    {
+        $normalized = strtoupper(trim($value));
+
+        if (preg_match(self::PATTERN, $normalized) !== 1) {
+            return null;
+        }
+
+        return new self($normalized);
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function isForeign(): bool
+    {
+        return $this->value[0] === 'Z';
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/BirthPlaceCode.php
+++ b/src/Data/BirthPlaceCode.php
@@ -9,50 +9,25 @@ use Robertogallea\CodiceFiscale\Exceptions\InvalidBirthPlaceCodeException;
  * positions 12-15 (e.g. "H501" for Roma, "Z404" for the USA).
  * Distinct from, and never equal to, an ISTAT code.
  */
-final class BirthPlaceCode implements \Stringable
+final class BirthPlaceCode extends AbstractValidatedCode
 {
-    private const PATTERN = '/^[A-Z][0-9]{3}$/';
-
-    private function __construct(
-        private readonly string $value,
-    ) {
+    protected static function pattern(): string
+    {
+        return '/^[A-Z][0-9]{3}$/';
     }
 
-    public static function from(string $value): self
+    protected static function exceptionClass(): string
     {
-        return self::tryFrom($value) ?? throw new InvalidBirthPlaceCodeException(
-            sprintf('"%s" is not a structurally valid birthplace code.', $value)
-        );
-    }
-
-    public static function tryFrom(string $value): ?self
-    {
-        $normalized = strtoupper(trim($value));
-
-        if (preg_match(self::PATTERN, $normalized) !== 1) {
-            return null;
-        }
-
-        return new self($normalized);
-    }
-
-    public function value(): string
-    {
-        return $this->value;
+        return InvalidBirthPlaceCodeException::class;
     }
 
     public function isForeign(): bool
     {
-        return $this->value[0] === 'Z';
+        return $this->value()[0] === 'Z';
     }
 
     public function equals(self $other): bool
     {
-        return $this->value === $other->value;
-    }
-
-    public function __toString(): string
-    {
-        return $this->value;
+        return $this->value() === $other->value();
     }
 }

--- a/src/Data/CountryCode.php
+++ b/src/Data/CountryCode.php
@@ -9,45 +9,20 @@ use Robertogallea\CodiceFiscale\Exceptions\InvalidCountryCodeException;
  * stati-esteri table. Distinct from the Z-prefixed BirthPlaceCode
  * a foreign birthplace is looked up by.
  */
-final class CountryCode implements \Stringable
+final class CountryCode extends AbstractValidatedCode
 {
-    private const PATTERN = '/^[A-Z]{3}$/';
-
-    private function __construct(
-        private readonly string $value,
-    ) {
+    protected static function pattern(): string
+    {
+        return '/^[A-Z]{3}$/';
     }
 
-    public static function from(string $value): self
+    protected static function exceptionClass(): string
     {
-        return self::tryFrom($value) ?? throw new InvalidCountryCodeException(
-            sprintf('"%s" is not a structurally valid ISO 3166-1 alpha-3 country code.', $value)
-        );
-    }
-
-    public static function tryFrom(string $value): ?self
-    {
-        $normalized = strtoupper(trim($value));
-
-        if (preg_match(self::PATTERN, $normalized) !== 1) {
-            return null;
-        }
-
-        return new self($normalized);
-    }
-
-    public function value(): string
-    {
-        return $this->value;
+        return InvalidCountryCodeException::class;
     }
 
     public function equals(self $other): bool
     {
-        return $this->value === $other->value;
-    }
-
-    public function __toString(): string
-    {
-        return $this->value;
+        return $this->value() === $other->value();
     }
 }

--- a/src/Data/CountryCode.php
+++ b/src/Data/CountryCode.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Data;
+
+use Robertogallea\CodiceFiscale\Exceptions\InvalidCountryCodeException;
+
+/**
+ * An ISO 3166-1 alpha-3 country code, sourced from MAECI's
+ * stati-esteri table. Distinct from the Z-prefixed BirthPlaceCode
+ * a foreign birthplace is looked up by.
+ */
+final class CountryCode implements \Stringable
+{
+    private const PATTERN = '/^[A-Z]{3}$/';
+
+    private function __construct(
+        private readonly string $value,
+    ) {
+    }
+
+    public static function from(string $value): self
+    {
+        return self::tryFrom($value) ?? throw new InvalidCountryCodeException(
+            sprintf('"%s" is not a structurally valid ISO 3166-1 alpha-3 country code.', $value)
+        );
+    }
+
+    public static function tryFrom(string $value): ?self
+    {
+        $normalized = strtoupper(trim($value));
+
+        if (preg_match(self::PATTERN, $normalized) !== 1) {
+            return null;
+        }
+
+        return new self($normalized);
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Data/DomesticBirthPlace.php
+++ b/src/Data/DomesticBirthPlace.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Data;
+
+final readonly class DomesticBirthPlace extends AbstractBirthPlace
+{
+    public function __construct(
+        BirthPlaceCode $code,
+        string $name,
+        private string $province,
+        private string $istatCode,
+        \DateTimeImmutable $validFrom,
+        ?\DateTimeImmutable $validTo = null,
+    ) {
+        parent::__construct($code, $name, $validFrom, $validTo);
+    }
+
+    public function province(): string
+    {
+        return $this->province;
+    }
+
+    public function istatCode(): string
+    {
+        return $this->istatCode;
+    }
+}

--- a/src/Data/ForeignBirthPlace.php
+++ b/src/Data/ForeignBirthPlace.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Data;
+
+final readonly class ForeignBirthPlace extends AbstractBirthPlace
+{
+    public function __construct(
+        BirthPlaceCode $code,
+        string $name,
+        private CountryCode $country,
+        \DateTimeImmutable $validFrom,
+        ?\DateTimeImmutable $validTo = null,
+    ) {
+        parent::__construct($code, $name, $validFrom, $validTo);
+    }
+
+    public function country(): CountryCode
+    {
+        return $this->country;
+    }
+}

--- a/src/Exceptions/InvalidBirthPlaceCodeException.php
+++ b/src/Exceptions/InvalidBirthPlaceCodeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Exceptions;
+
+class InvalidBirthPlaceCodeException extends \InvalidArgumentException
+{
+}

--- a/src/Exceptions/InvalidCountryCodeException.php
+++ b/src/Exceptions/InvalidCountryCodeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Exceptions;
+
+class InvalidCountryCodeException extends \InvalidArgumentException
+{
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,37 @@
 <?php
 
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\DomesticBirthPlace;
 use Tests\TestCase;
 
 uses(TestCase::class)->in('Feature');
+
+/**
+ * Modelled on the real Abbadia Cerreto municipality (cadastral code
+ * A004), which moved from the province of Milano to the newly formed
+ * province of Lodi on 1992-04-16, per ANPR's comuni archive. Both
+ * eras share the same BirthPlaceCode.
+ */
+function abbadiaCerretoUnderMilano(): DomesticBirthPlace
+{
+    return new DomesticBirthPlace(
+        code: BirthPlaceCode::from('A004'),
+        name: 'ABBADIA CERRETO',
+        province: 'MI',
+        istatCode: '015001',
+        validFrom: new DateTimeImmutable('1861-03-17'),
+        validTo: new DateTimeImmutable('1992-04-16'),
+    );
+}
+
+function abbadiaCerretoUnderLodi(): DomesticBirthPlace
+{
+    return new DomesticBirthPlace(
+        code: BirthPlaceCode::from('A004'),
+        name: 'ABBADIA CERRETO',
+        province: 'LO',
+        istatCode: '098001',
+        validFrom: new DateTimeImmutable('1992-04-16'),
+        validTo: null,
+    );
+}

--- a/tests/Support/InMemoryBirthPlaceRepository.php
+++ b/tests/Support/InMemoryBirthPlaceRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Support;
+
+use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+
+/**
+ * The project's one designed test seam: a BirthPlaceRepository seeded
+ * entirely in memory, with no I/O. Core tickets' tests use this
+ * instead of the real Eloquent-backed implementation.
+ */
+final class InMemoryBirthPlaceRepository implements BirthPlaceRepository
+{
+    /** @var array<string, list<BirthPlace>> */
+    private array $recordsByCode = [];
+
+    public function __construct(BirthPlace ...$records)
+    {
+        foreach ($records as $record) {
+            $this->recordsByCode[$record->code()->value()][] = $record;
+        }
+    }
+
+    public function find(BirthPlaceCode $code, ?\DateTimeImmutable $on = null): ?BirthPlace
+    {
+        $on ??= new \DateTimeImmutable('today');
+
+        foreach ($this->recordsByCode[$code->value()] ?? [] as $record) {
+            if ($record->wasValidOn($on)) {
+                return $record;
+            }
+        }
+
+        return null;
+    }
+
+    public function existedEver(BirthPlaceCode $code): bool
+    {
+        return isset($this->recordsByCode[$code->value()]);
+    }
+}

--- a/tests/Unit/BirthPlaceCodeTest.php
+++ b/tests/Unit/BirthPlaceCodeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Exceptions\InvalidBirthPlaceCodeException;
+
+test('from() accepts a real domestic cadastral code', function () {
+    expect(BirthPlaceCode::from('H501')->value())->toBe('H501');
+});
+
+test('from() normalizes lowercase input', function () {
+    expect(BirthPlaceCode::from('h501')->value())->toBe('H501');
+});
+
+test('isForeign() is true only for Z-prefixed codes', function () {
+    expect(BirthPlaceCode::from('H501')->isForeign())->toBeFalse()
+        ->and(BirthPlaceCode::from('Z404')->isForeign())->toBeTrue();
+});
+
+test('from() throws for malformed input', function (string $code) {
+    expect(fn () => BirthPlaceCode::from($code))->toThrow(InvalidBirthPlaceCodeException::class);
+})->with([
+    'too short' => ['H50'],
+    'too long' => ['H5011'],
+    'digit prefix instead of letter' => ['1501'],
+    'omocodia letter instead of digit' => ['H5L1'],
+]);
+
+test('tryFrom() returns null instead of throwing for the same malformed input', function () {
+    expect(BirthPlaceCode::tryFrom('H50'))->toBeNull();
+});
+
+test('equals() compares by value, not identity', function () {
+    $a = BirthPlaceCode::from('H501');
+    $b = BirthPlaceCode::from('h501');
+    $c = BirthPlaceCode::from('Z404');
+
+    expect($a->equals($b))->toBeTrue()
+        ->and($a->equals($c))->toBeFalse();
+});

--- a/tests/Unit/BirthPlaceTypeShapeTest.php
+++ b/tests/Unit/BirthPlaceTypeShapeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
+use Robertogallea\CodiceFiscale\Data\DomesticBirthPlace;
+use Robertogallea\CodiceFiscale\Data\ForeignBirthPlace;
+
+test('both flavors implement the shared BirthPlace interface', function () {
+    expect(is_a(DomesticBirthPlace::class, BirthPlace::class, true))->toBeTrue()
+        ->and(is_a(ForeignBirthPlace::class, BirthPlace::class, true))->toBeTrue();
+});
+
+test('DomesticBirthPlace has no country() - foreign-only concept', function () {
+    expect(method_exists(DomesticBirthPlace::class, 'country'))->toBeFalse();
+});
+
+test('ForeignBirthPlace has no province() or istatCode() - domestic-only concepts', function () {
+    expect(method_exists(ForeignBirthPlace::class, 'province'))->toBeFalse()
+        ->and(method_exists(ForeignBirthPlace::class, 'istatCode'))->toBeFalse();
+});

--- a/tests/Unit/CountryCodeTest.php
+++ b/tests/Unit/CountryCodeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Data\CountryCode;
+use Robertogallea\CodiceFiscale\Exceptions\InvalidCountryCodeException;
+
+test('from() accepts a real ISO 3166-1 alpha-3 code', function () {
+    expect(CountryCode::from('USA')->value())->toBe('USA');
+});
+
+test('from() normalizes lowercase input', function () {
+    expect(CountryCode::from('usa')->value())->toBe('USA');
+});
+
+test('from() throws for malformed input', function (string $code) {
+    expect(fn () => CountryCode::from($code))->toThrow(InvalidCountryCodeException::class);
+})->with([
+    'too short' => ['US'],
+    'too long' => ['USAA'],
+    'contains a digit' => ['US1'],
+]);
+
+test('tryFrom() returns null instead of throwing for the same malformed input', function () {
+    expect(CountryCode::tryFrom('US'))->toBeNull();
+});
+
+test('equals() compares by value, not identity', function () {
+    $a = CountryCode::from('USA');
+    $b = CountryCode::from('usa');
+    $c = CountryCode::from('FRA');
+
+    expect($a->equals($b))->toBeTrue()
+        ->and($a->equals($c))->toBeFalse();
+});

--- a/tests/Unit/DomesticBirthPlaceTest.php
+++ b/tests/Unit/DomesticBirthPlaceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+test('exposes its code, name, province and ISTAT code', function () {
+    $place = abbadiaCerretoUnderLodi();
+
+    expect($place->code()->value())->toBe('A004')
+        ->and($place->name())->toBe('ABBADIA CERRETO')
+        ->and($place->province())->toBe('LO')
+        ->and($place->istatCode())->toBe('098001');
+});
+
+test('wasValidOn() is true for a date within the era, false outside it', function () {
+    $milano = abbadiaCerretoUnderMilano();
+
+    expect($milano->wasValidOn(new DateTimeImmutable('1900-01-01')))->toBeTrue()
+        ->and($milano->wasValidOn(new DateTimeImmutable('1992-04-15')))->toBeTrue()
+        ->and($milano->wasValidOn(new DateTimeImmutable('1992-04-16')))->toBeFalse()
+        ->and($milano->wasValidOn(new DateTimeImmutable('1860-01-01')))->toBeFalse();
+});
+
+test('wasValidOn() is true indefinitely into the future for an open-ended (still valid) record', function () {
+    $lodi = abbadiaCerretoUnderLodi();
+
+    expect($lodi->wasValidOn(new DateTimeImmutable('1992-04-16')))->toBeTrue()
+        ->and($lodi->wasValidOn(new DateTimeImmutable('today')))->toBeTrue()
+        ->and($lodi->wasValidOn(new DateTimeImmutable('2100-01-01')))->toBeTrue()
+        ->and($lodi->wasValidOn(new DateTimeImmutable('1992-04-15')))->toBeFalse();
+});

--- a/tests/Unit/ForeignBirthPlaceTest.php
+++ b/tests/Unit/ForeignBirthPlaceTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\CountryCode;
+use Robertogallea\CodiceFiscale\Data\ForeignBirthPlace;
+
+test('exposes its code, name and country', function () {
+    $place = new ForeignBirthPlace(
+        code: BirthPlaceCode::from('Z404'),
+        name: "STATI UNITI D'AMERICA",
+        country: CountryCode::from('USA'),
+        validFrom: new DateTimeImmutable('1900-01-01'),
+        validTo: null,
+    );
+
+    expect($place->code()->value())->toBe('Z404')
+        ->and($place->name())->toBe("STATI UNITI D'AMERICA")
+        ->and($place->country()->value())->toBe('USA')
+        ->and($place->wasValidOn(new DateTimeImmutable('today')))->toBeTrue();
+});

--- a/tests/Unit/InMemoryBirthPlaceRepositoryTest.php
+++ b/tests/Unit/InMemoryBirthPlaceRepositoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\CountryCode;
+use Robertogallea\CodiceFiscale\Data\ForeignBirthPlace;
+use Tests\Support\InMemoryBirthPlaceRepository;
+
+test('find() resolves the era-record valid on the given date', function () {
+    $repository = new InMemoryBirthPlaceRepository(
+        abbadiaCerretoUnderMilano(),
+        abbadiaCerretoUnderLodi(),
+    );
+    $code = BirthPlaceCode::from('A004');
+
+    $beforeChange = $repository->find($code, new DateTimeImmutable('1950-01-01'));
+    $afterChange = $repository->find($code, new DateTimeImmutable('2000-01-01'));
+
+    expect($beforeChange->province())->toBe('MI')
+        ->and($afterChange->province())->toBe('LO');
+});
+
+test('find() defaults to today when no date is given', function () {
+    $repository = new InMemoryBirthPlaceRepository(abbadiaCerretoUnderLodi());
+
+    expect($repository->find(BirthPlaceCode::from('A004'))->province())->toBe('LO');
+});
+
+test('find() returns null for a code that never existed', function () {
+    $repository = new InMemoryBirthPlaceRepository(abbadiaCerretoUnderLodi());
+
+    expect($repository->find(BirthPlaceCode::from('Z999')))->toBeNull();
+});
+
+test('find() returns null for a code that existed, but not on the given date', function () {
+    $repository = new InMemoryBirthPlaceRepository(abbadiaCerretoUnderMilano());
+
+    expect($repository->find(BirthPlaceCode::from('A004'), new DateTimeImmutable('1800-01-01')))->toBeNull();
+});
+
+test('existedEver() distinguishes a never-known code from a known one', function () {
+    $repository = new InMemoryBirthPlaceRepository(abbadiaCerretoUnderMilano());
+
+    expect($repository->existedEver(BirthPlaceCode::from('A004')))->toBeTrue()
+        ->and($repository->existedEver(BirthPlaceCode::from('Z999')))->toBeFalse();
+});
+
+test('resolves a foreign birthplace the same way', function () {
+    $usa = new ForeignBirthPlace(
+        code: BirthPlaceCode::from('Z404'),
+        name: "STATI UNITI D'AMERICA",
+        country: CountryCode::from('USA'),
+        validFrom: new DateTimeImmutable('1900-01-01'),
+    );
+    $repository = new InMemoryBirthPlaceRepository($usa);
+
+    expect($repository->find(BirthPlaceCode::from('Z404'))->country()->value())->toBe('USA');
+});


### PR DESCRIPTION
Closes #78.

## Summary
- `BirthPlace` interface + `DomesticBirthPlace`/`ForeignBirthPlace` implementations, sharing `[validFrom, validTo)` bookkeeping via an abstract base while each adds only its own genuinely distinct field (province/istatCode vs country) — enforced by the type system, not a nullable column.
- `BirthPlaceCode`/`CountryCode` validated value objects (sharing a small `AbstractValidatedCode` base after code review deduplication).
- `BirthPlaceRepository` contract: `find(code, ?on)` and `existedEver(code)`, distinguishing "code never existed" from "code existed, not on this date."
- `InMemoryBirthPlaceRepository` (`tests/Support/`) — the project's one designed test seam, seeded entirely in memory.
- Fixture modelled on the real Abbadia Cerreto municipality (cadastral code A004), which moved from province Milano to the newly formed province Lodi on 1992-04-16, per ANPR's comuni archive.

## Test plan
- [x] 58 Pest tests passing
- [x] PHPStan level max passes clean
- [x] `php-cs-fixer --dry-run` passes
- [x] Reviewed via `/code-review` (Standards + Spec axes) — one fix applied (deduplicated `BirthPlaceCode`/`CountryCode`); two findings deliberately not acted on (documented in the fix commit)