### PR TITLE
Generator (Person, Gender, NameEncoder, DateEncoder, BirthPlaceEncoder, NameNormalizer)

### DIFF
--- a/src/Contracts/NameNormalizer.php
+++ b/src/Contracts/NameNormalizer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Contracts;
+
+interface NameNormalizer
+{
+    public function normalize(string $name): string;
+}

--- a/src/Contracts/NameNormalizer.php
+++ b/src/Contracts/NameNormalizer.php
@@ -2,6 +2,11 @@
 
 namespace Robertogallea\CodiceFiscale\Contracts;
 
+/**
+ * Normalizes a name as a person actually typed it (accents,
+ * apostrophes, mixed case, extra whitespace) into the plain
+ * uppercase form the encoding algorithm expects.
+ */
 interface NameNormalizer
 {
     public function normalize(string $name): string;

--- a/src/Data/Person.php
+++ b/src/Data/Person.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Data;
+
+use Robertogallea\CodiceFiscale\Enums\Gender;
+
+final readonly class Person
+{
+    public function __construct(
+        public string $firstName,
+        public string $lastName,
+        public \DateTimeImmutable $birthDate,
+        public BirthPlaceCode $birthPlace,
+        public Gender $gender,
+    ) {
+    }
+}

--- a/src/Enums/Gender.php
+++ b/src/Enums/Gender.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Enums;
+
+enum Gender: string
+{
+    case Male = 'M';
+    case Female = 'F';
+}

--- a/src/Generation/BirthPlaceEncoder.php
+++ b/src/Generation/BirthPlaceEncoder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Generation;
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+
+final class BirthPlaceEncoder
+{
+    public function encode(BirthPlaceCode $birthPlace): string
+    {
+        return $birthPlace->value();
+    }
+}

--- a/src/Generation/DateEncoder.php
+++ b/src/Generation/DateEncoder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Generation;
+
+use Robertogallea\CodiceFiscale\Enums\Gender;
+
+final class DateEncoder
+{
+    private const MONTH_LETTERS = [
+        1 => 'A', 2 => 'B', 3 => 'C', 4 => 'D', 5 => 'E',
+        6 => 'H', 7 => 'L', 8 => 'M', 9 => 'P', 10 => 'R',
+        11 => 'S', 12 => 'T',
+    ];
+
+    public function encode(\DateTimeImmutable $birthDate, Gender $gender): string
+    {
+        $year = substr($birthDate->format('Y'), -2);
+        $month = self::MONTH_LETTERS[(int) $birthDate->format('n')];
+
+        $day = (int) $birthDate->format('j');
+        if ($gender === Gender::Female) {
+            $day += 40;
+        }
+
+        return $year.$month.str_pad((string) $day, 2, '0', STR_PAD_LEFT);
+    }
+}

--- a/src/Generation/Generator.php
+++ b/src/Generation/Generator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Generation;
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Contracts\NameNormalizer;
+use Robertogallea\CodiceFiscale\Data\Person;
+
+final class Generator
+{
+    public function __construct(
+        private readonly NameEncoder $nameEncoder = new NameEncoder(),
+        private readonly DateEncoder $dateEncoder = new DateEncoder(),
+        private readonly BirthPlaceEncoder $birthPlaceEncoder = new BirthPlaceEncoder(),
+        private readonly Checksum $checksum = new Checksum(),
+        private readonly NameNormalizer $nameNormalizer = new ItalianNameNormalizer(),
+    ) {
+    }
+
+    public function generate(Person $person): CodiceFiscale
+    {
+        $surnameCode = $this->nameEncoder->surnameCode(
+            $this->nameNormalizer->normalize($person->lastName)
+        );
+        $nameCode = $this->nameEncoder->nameCode(
+            $this->nameNormalizer->normalize($person->firstName)
+        );
+        $dateCode = $this->dateEncoder->encode($person->birthDate, $person->gender);
+        $birthPlaceCode = $this->birthPlaceEncoder->encode($person->birthPlace);
+
+        $first15 = $surnameCode.$nameCode.$dateCode.$birthPlaceCode;
+
+        return CodiceFiscale::from($first15.$this->checksum->calculate($first15));
+    }
+}

--- a/src/Generation/ItalianNameNormalizer.php
+++ b/src/Generation/ItalianNameNormalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Generation;
+
+use Robertogallea\CodiceFiscale\Contracts\NameNormalizer;
+
+/**
+ * Normalizes a name as a person actually typed it (accents,
+ * apostrophes, mixed case, extra whitespace) into the plain
+ * uppercase A-Z form the encoding algorithm expects. Handles Latin-
+ * script diacritics; broader multi-script transliteration is out of
+ * scope for this implementation.
+ */
+final class ItalianNameNormalizer implements NameNormalizer
+{
+    private const TRANSLITERATION = [
+        'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'A',
+        'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E',
+        'Ì' => 'I', 'Í' => 'I', 'Î' => 'I', 'Ï' => 'I',
+        'Ò' => 'O', 'Ó' => 'O', 'Ô' => 'O', 'Õ' => 'O', 'Ö' => 'O',
+        'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U',
+        'Ç' => 'C', 'Ñ' => 'N', 'Ý' => 'Y',
+    ];
+
+    public function normalize(string $name): string
+    {
+        $upper = mb_strtoupper(trim($name), 'UTF-8');
+        $transliterated = strtr($upper, self::TRANSLITERATION);
+
+        return preg_replace('/[^A-Z]/', '', $transliterated) ?? '';
+    }
+}

--- a/src/Generation/NameEncoder.php
+++ b/src/Generation/NameEncoder.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Generation;
+
+/**
+ * Encodes an already-normalized (uppercase, A-Z only) surname or
+ * first name into its 3-letter code. Expects normalize() to have
+ * already run - see NameNormalizer.
+ */
+final class NameEncoder
+{
+    private const CONSONANTS = [
+        'B', 'C', 'D', 'F', 'G', 'H', 'J', 'K',
+        'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T',
+        'V', 'W', 'X', 'Y', 'Z',
+    ];
+
+    private const VOWELS = ['A', 'E', 'I', 'O', 'U'];
+
+    public function surnameCode(string $normalizedSurname): string
+    {
+        $consonants = $this->consonantsOf($normalizedSurname);
+
+        $code = implode('', array_slice($consonants, 0, 3));
+
+        return $this->padWithVowelsThenX($code, $normalizedSurname);
+    }
+
+    public function nameCode(string $normalizedName): string
+    {
+        $consonants = $this->consonantsOf($normalizedName);
+
+        if (count($consonants) <= 3) {
+            $code = implode('', $consonants);
+        } else {
+            // First name special case: skip the 2nd consonant when
+            // there are 4 or more, taking the 1st, 3rd and 4th instead.
+            $code = $consonants[0].$consonants[2].$consonants[3];
+        }
+
+        return $this->padWithVowelsThenX($code, $normalizedName);
+    }
+
+    /** @return list<string> */
+    private function consonantsOf(string $normalized): array
+    {
+        return $this->lettersMatching($normalized, self::CONSONANTS);
+    }
+
+    /** @return list<string> */
+    private function vowelsOf(string $normalized): array
+    {
+        return $this->lettersMatching($normalized, self::VOWELS);
+    }
+
+    /**
+     * @param  list<string>  $allowedLetters
+     * @return list<string>
+     */
+    private function lettersMatching(string $normalized, array $allowedLetters): array
+    {
+        return array_values(array_filter(
+            str_split($normalized),
+            static fn (string $letter): bool => in_array($letter, $allowedLetters, true)
+        ));
+    }
+
+    private function padWithVowelsThenX(string $code, string $normalized): string
+    {
+        if (strlen($code) < 3) {
+            foreach ($this->vowelsOf($normalized) as $vowel) {
+                if (strlen($code) >= 3) {
+                    break;
+                }
+                $code .= $vowel;
+            }
+        }
+
+        return str_pad($code, 3, 'X');
+    }
+}

--- a/tests/Unit/BirthPlaceEncoderTest.php
+++ b/tests/Unit/BirthPlaceEncoderTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Generation\BirthPlaceEncoder;
+
+test('encodes a birthplace code as its 4-character value', function () {
+    expect((new BirthPlaceEncoder())->encode(BirthPlaceCode::from('H501')))->toBe('H501');
+});

--- a/tests/Unit/DateEncoderTest.php
+++ b/tests/Unit/DateEncoderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Generation\DateEncoder;
+
+test('encodes a male birth date as year, month letter, and day', function () {
+    $encoder = new DateEncoder();
+
+    expect($encoder->encode(new DateTimeImmutable('1985-08-01'), Gender::Male))->toBe('85M01');
+});
+
+test('adds 40 to the day for a female birth date', function () {
+    $encoder = new DateEncoder();
+
+    expect($encoder->encode(new DateTimeImmutable('1995-05-05'), Gender::Female))->toBe('95E45');
+});
+
+test('encodes other real fixtures correctly', function (string $date, Gender $gender, string $expected) {
+    expect((new DateEncoder())->encode(new DateTimeImmutable($date), $gender))->toBe($expected);
+})->with([
+    'January, single-digit day' => ['1990-01-01', Gender::Male, '90A01'],
+    'December' => ['1971-12-05', Gender::Male, '71T05'],
+    'June (letter H, not F)' => ['2000-06-15', Gender::Male, '00H15'],
+]);

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\Person;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Generation\Generator;
+
+test('generates a checksum-correct code for a known fixture', function () {
+    $person = new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1995-05-05'),
+        birthPlace: BirthPlaceCode::from('F205'),
+        gender: Gender::Male,
+    );
+
+    expect((new Generator())->generate($person)->value())->toBe('RSSMRA95E05F205Z');
+});
+
+test('generates other real fixtures correctly', function (string $first, string $last, string $date, string $place, Gender $gender, string $expected) {
+    $person = new Person(
+        firstName: $first,
+        lastName: $last,
+        birthDate: new DateTimeImmutable($date),
+        birthPlace: BirthPlaceCode::from($place),
+        gender: $gender,
+    );
+
+    expect((new Generator())->generate($person)->value())->toBe($expected);
+})->with([
+    'short first name padded with X' => ['Ma', 'Rossi', '1995-05-05', 'F205', Gender::Male, 'RSSMAX95E05F205P'],
+    'both names need padding' => ['ASH', 'OS', '1990-01-01', 'F205', Gender::Male, 'SOXSHA90A01F205B'],
+    'surname needs padding, name is exact' => ['MARIO', 'OM', '1990-01-01', 'F205', Gender::Male, 'MOXMRA90A01F205S'],
+    'first name has zero consonants' => ['IO', 'ROSSI', '1990-01-01', 'F205', Gender::Male, 'RSSIOX90A01F205V'],
+    'female (day + 40)' => ['Mario', 'Rossi', '1995-05-05', 'F205', Gender::Female, 'RSSMRA95E45F205D'],
+]);
+
+test('generates a correct code from accented, apostrophe-containing names without pre-normalizing', function () {
+    $person = new Person(
+        firstName: 'José',
+        lastName: "D'Angelo",
+        birthDate: new DateTimeImmutable('1985-08-01'),
+        birthPlace: BirthPlaceCode::from('H501'),
+        gender: Gender::Male,
+    );
+
+    // DANGELO -> consonants D,N,G (surname rule: first 3, no skip) -> DNG
+    // JOSE -> consonants J,S (<=3) -> JS + vowel O -> JSO
+    // 1985-08-01 male -> 85 M 01; Roma -> H501
+    expect((new Generator())->generate($person)->value())->toBe('DNGJSO85M01H501C');
+});

--- a/tests/Unit/ItalianNameNormalizerTest.php
+++ b/tests/Unit/ItalianNameNormalizerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Generation\ItalianNameNormalizer;
+
+test('uppercases a plain name', function () {
+    expect((new ItalianNameNormalizer())->normalize('mario'))->toBe('MARIO');
+});
+
+test('transliterates accented letters instead of dropping them', function () {
+    expect((new ItalianNameNormalizer())->normalize('José'))->toBe('JOSE');
+});
+
+test('strips apostrophes', function () {
+    expect((new ItalianNameNormalizer())->normalize("D'Angelo"))->toBe('DANGELO');
+});
+
+test('strips extra whitespace', function () {
+    expect((new ItalianNameNormalizer())->normalize('  Mario  Luigi  '))->toBe('MARIOLUIGI');
+});
+
+test('normalizes other accented and punctuated real names', function (string $input, string $expected) {
+    expect((new ItalianNameNormalizer())->normalize($input))->toBe($expected);
+})->with([
+    'ç and ñ' => ['François Núñez', 'FRANCOISNUNEZ'],
+    'hyphenated' => ['Anne-Marie', 'ANNEMARIE'],
+    'already uppercase with accent' => ['ÀNGELA', 'ANGELA'],
+]);

--- a/tests/Unit/NameEncoderTest.php
+++ b/tests/Unit/NameEncoderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Generation\NameEncoder;
+
+test('surnameCode() takes the first three consonants', function () {
+    expect((new NameEncoder())->surnameCode('ROSSI'))->toBe('RSS');
+});
+
+test('surnameCode() real fixtures, including padding with vowels and X', function (string $surname, string $expected) {
+    expect((new NameEncoder())->surnameCode($surname))->toBe($expected);
+})->with([
+    'one consonant, needs a vowel and an X' => ['OS', 'SOX'],
+    'one consonant, needs a vowel, none left after' => ['OM', 'MOX'],
+    'no consonants at all' => ['IO', 'IOX'],
+]);
+
+test('nameCode() takes all consonants when there are three or fewer', function (string $name, string $expected) {
+    expect((new NameEncoder())->nameCode($name))->toBe($expected);
+})->with([
+    'exactly three consonants' => ['MARIO', 'MRA'],
+    'two consonants, padded with a vowel' => ['ASH', 'SHA'],
+    'no consonants, padded with vowels then X' => ['IO', 'IOX'],
+    'short name, padded entirely with X' => ['MA', 'MAX'],
+]);
+
+test('nameCode() skips the 2nd consonant when there are four or more, using the 1st/3rd/4th', function () {
+    // ALBERTO -> consonants L,B,R,T (4) -> skip the 2nd (B) -> L,R,T
+    expect((new NameEncoder())->nameCode('ALBERTO'))->toBe('LRT');
+});


### PR DESCRIPTION
Closes #79.

## Summary
- `Person` DTO, `Gender` backed enum (`M`/`F`), `Generator::generate(Person): CodiceFiscale`.
- `NameEncoder` ports the 2.x consonant/vowel algorithm for both surname and first-name codes, including first names' special case (skip the 2nd consonant when there are 4+, use 1st/3rd/4th instead).
- `NameNormalizer`/`ItalianNameNormalizer`: accent transliteration + punctuation/whitespace stripping, composed automatically inside `Generator` — callers pass names as typed.
- `DateEncoder`, `BirthPlaceEncoder` (thin, intentional — architectural symmetry + stable seam per the ticket's own framing).

## Test plan
- [x] 87 Pest tests passing, including 6 real fixtures ported from the deleted 2.x generation test suite, one hand-derived from the documented 4+-consonant rule (`ALBERTO` → `LRT`), and one accented/apostrophe end-to-end fixture (`José`/`D'Angelo`) built by combining independently-derived encoder output with the already-verified `Checksum` service
- [x] PHPStan level max passes clean
- [x] `php-cs-fixer --dry-run` passes
- [x] Reviewed via `/code-review` (Standards + Spec axes) — no hard violations; the Spec reviewer independently re-derived both hand-built fixtures by hand and confirmed them correct; one fix applied (documented the `NameNormalizer` contract for consistency with its sibling contracts)