### PR TITLE
Omocodia service

### DIFF
--- a/src/CodiceFiscale.php
+++ b/src/CodiceFiscale.php
@@ -3,6 +3,7 @@
 namespace Robertogallea\CodiceFiscale;
 
 use Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException;
+use Robertogallea\CodiceFiscale\Omocodia\Omocodia;
 
 final class CodiceFiscale implements \Stringable
 {
@@ -51,5 +52,17 @@ final class CodiceFiscale implements \Stringable
     public function __toString(): string
     {
         return $this->value;
+    }
+
+    /**
+     * True when both codes decode to the same person-derived data,
+     * regardless of omocodia substitution - i.e. they share a
+     * canonical form.
+     */
+    public function isEquivalentTo(self $other): bool
+    {
+        $omocodia = new Omocodia();
+
+        return $omocodia->canonical($this)->value() === $omocodia->canonical($other)->value();
     }
 }

--- a/src/Omocodia/Omocodia.php
+++ b/src/Omocodia/Omocodia.php
@@ -42,7 +42,9 @@ final class Omocodia
         $characters = str_split($cf->value());
 
         foreach (self::ELIGIBLE_POSITIONS as $position) {
-            $characters[$position] = self::LETTER_TO_DIGIT[$characters[$position]] ?? $characters[$position];
+            if ($this->isSubstituted($characters, $position)) {
+                $characters[$position] = self::LETTER_TO_DIGIT[$characters[$position]];
+            }
         }
 
         return $this->rebuild($characters);
@@ -98,16 +100,31 @@ final class Omocodia
         yield from $combinations;
     }
 
+    /**
+     * How many of the 7 eligible positions are currently letter-
+     * substituted, from 0 (canonical) to 7 (every position
+     * substituted). This is a count, not an ordinal or cumulative
+     * "level" in any hierarchical sense - distinct combinations of
+     * substituted positions can share the same count (there are
+     * C(7,k) combinations for count k), so this number alone never
+     * identifies which variant a code is.
+     */
     public function level(CodiceFiscale $cf): int
     {
         $characters = str_split($cf->value());
 
         $substituted = array_filter(
             self::ELIGIBLE_POSITIONS,
-            static fn (int $position): bool => isset(self::LETTER_TO_DIGIT[$characters[$position]])
+            fn (int $position): bool => $this->isSubstituted($characters, $position)
         );
 
         return count($substituted);
+    }
+
+    /** @param array<int, string> $characters */
+    private function isSubstituted(array $characters, int $position): bool
+    {
+        return isset(self::LETTER_TO_DIGIT[$characters[$position]]);
     }
 
     /** @param array<int, string> $characters */

--- a/src/Omocodia/Omocodia.php
+++ b/src/Omocodia/Omocodia.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Omocodia;
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Generation\Checksum;
+
+/**
+ * Handles omocodia: the Agenzia delle Entrate's collision-resolution
+ * scheme, which substitutes a subset of 7 fixed digit positions
+ * (year, day, birthplace-code digits) with corresponding letters.
+ * Any of the 2^7 = 128 subsets may be substituted independently -
+ * omocodia is a per-position combination, not a cumulative level.
+ */
+final class Omocodia
+{
+    /**
+     * The 7 omocodia-eligible positions (0-indexed within the
+     * 16-character code): year digits, day digits, then the last 3
+     * digits of the birthplace code. The birthplace-code prefix
+     * letter (position 11) is never substituted.
+     */
+    private const ELIGIBLE_POSITIONS = [6, 7, 9, 10, 12, 13, 14];
+
+    private const DIGIT_TO_LETTER = [
+        '0' => 'L', '1' => 'M', '2' => 'N', '3' => 'P', '4' => 'Q',
+        '5' => 'R', '6' => 'S', '7' => 'T', '8' => 'U', '9' => 'V',
+    ];
+
+    private const LETTER_TO_DIGIT = [
+        'L' => '0', 'M' => '1', 'N' => '2', 'P' => '3', 'Q' => '4',
+        'R' => '5', 'S' => '6', 'T' => '7', 'U' => '8', 'V' => '9',
+    ];
+
+    public function __construct(
+        private readonly Checksum $checksum = new Checksum(),
+    ) {
+    }
+
+    public function canonical(CodiceFiscale $cf): CodiceFiscale
+    {
+        $characters = str_split($cf->value());
+
+        foreach (self::ELIGIBLE_POSITIONS as $position) {
+            $characters[$position] = self::LETTER_TO_DIGIT[$characters[$position]] ?? $characters[$position];
+        }
+
+        return $this->rebuild($characters);
+    }
+
+    /**
+     * The full 2^7 = 128-member set of codes sharing the same
+     * person-derived data as $cf, one per combination of digit-or-
+     * letter across the 7 eligible positions.
+     *
+     * @return iterable<CodiceFiscale>
+     */
+    public function variants(CodiceFiscale $cf): iterable
+    {
+        $canonicalCharacters = str_split($this->canonical($cf)->value());
+
+        $optionsPerPosition = array_map(
+            static fn (int $position): array => [
+                $canonicalCharacters[$position],
+                self::DIGIT_TO_LETTER[$canonicalCharacters[$position]],
+            ],
+            self::ELIGIBLE_POSITIONS
+        );
+
+        foreach ($this->cartesianProduct($optionsPerPosition) as $combination) {
+            $characters = $canonicalCharacters;
+            foreach (self::ELIGIBLE_POSITIONS as $index => $position) {
+                $characters[$position] = $combination[$index];
+            }
+
+            yield $this->rebuild($characters);
+        }
+    }
+
+    /**
+     * @param  list<list<string>>  $optionsPerPosition
+     * @return iterable<list<string>>
+     */
+    private function cartesianProduct(array $optionsPerPosition): iterable
+    {
+        $combinations = [[]];
+
+        foreach ($optionsPerPosition as $options) {
+            $next = [];
+            foreach ($combinations as $combination) {
+                foreach ($options as $option) {
+                    $next[] = [...$combination, $option];
+                }
+            }
+            $combinations = $next;
+        }
+
+        yield from $combinations;
+    }
+
+    public function level(CodiceFiscale $cf): int
+    {
+        $characters = str_split($cf->value());
+
+        $substituted = array_filter(
+            self::ELIGIBLE_POSITIONS,
+            static fn (int $position): bool => isset(self::LETTER_TO_DIGIT[$characters[$position]])
+        );
+
+        return count($substituted);
+    }
+
+    /** @param array<int, string> $characters */
+    private function rebuild(array $characters): CodiceFiscale
+    {
+        $first15 = implode('', array_slice($characters, 0, 15));
+
+        return CodiceFiscale::from($first15.$this->checksum->calculate($first15));
+    }
+}

--- a/tests/Unit/CodiceFiscaleTest.php
+++ b/tests/Unit/CodiceFiscaleTest.php
@@ -2,6 +2,7 @@
 
 use Robertogallea\CodiceFiscale\CodiceFiscale;
 use Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException;
+use Robertogallea\CodiceFiscale\Omocodia\Omocodia;
 
 test('from() constructs a value object exposing the given code', function () {
     $cf = CodiceFiscale::from('RSSMRA95E05F205Z');
@@ -64,6 +65,19 @@ test('isEquivalentTo() is true for a canonical code and its own omocodia variant
 
     expect($canonical->isEquivalentTo($variant))->toBeTrue()
         ->and($variant->isEquivalentTo($canonical))->toBeTrue();
+});
+
+test('isEquivalentTo() is true between a canonical code and every one of its 128 variants', function () {
+    $canonical = CodiceFiscale::from('RSSMRA95E05F205Z');
+    $omocodia = new Omocodia();
+
+    $variants = iterator_to_array($omocodia->variants($canonical));
+    expect($variants)->toHaveCount(128);
+
+    foreach ($variants as $variant) {
+        expect($canonical->isEquivalentTo($variant))->toBeTrue()
+            ->and($variant->isEquivalentTo($canonical))->toBeTrue();
+    }
 });
 
 test('isEquivalentTo() is true for a code compared to itself', function () {

--- a/tests/Unit/CodiceFiscaleTest.php
+++ b/tests/Unit/CodiceFiscaleTest.php
@@ -57,3 +57,24 @@ test('casts to string as its value', function () {
 
     expect((string) $cf)->toBe('RSSMRA95E05F205Z');
 });
+
+test('isEquivalentTo() is true for a canonical code and its own omocodia variant', function () {
+    $canonical = CodiceFiscale::from('RSSMRA95E05F205Z');
+    $variant = CodiceFiscale::from('RSSMRA95E05F20RU');
+
+    expect($canonical->isEquivalentTo($variant))->toBeTrue()
+        ->and($variant->isEquivalentTo($canonical))->toBeTrue();
+});
+
+test('isEquivalentTo() is true for a code compared to itself', function () {
+    $cf = CodiceFiscale::from('RSSMRA95E05F205Z');
+
+    expect($cf->isEquivalentTo($cf))->toBeTrue();
+});
+
+test('isEquivalentTo() is false for an unrelated code', function () {
+    $mario = CodiceFiscale::from('RSSMRA95E05F205Z');
+    $unrelated = CodiceFiscale::from('RBRRHR93L09Z357P');
+
+    expect($mario->isEquivalentTo($unrelated))->toBeFalse();
+});

--- a/tests/Unit/OmocodiaTest.php
+++ b/tests/Unit/OmocodiaTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Generation\Checksum;
+use Robertogallea\CodiceFiscale\Omocodia\Omocodia;
+
+test('canonical() leaves an already-canonical code unchanged', function () {
+    $cf = CodiceFiscale::from('RSSMRA95E05F205Z');
+
+    expect((new Omocodia())->canonical($cf)->value())->toBe('RSSMRA95E05F205Z');
+});
+
+test('canonical() reverses a single omocodia substitution back to its digit', function () {
+    $variant = CodiceFiscale::from('RSSMRA95E05F20RU');
+
+    expect((new Omocodia())->canonical($variant)->value())->toBe('RSSMRA95E05F205Z');
+});
+
+test('canonical() reverses every substitution level back to the same base code', function (string $variant) {
+    expect((new Omocodia())->canonical(CodiceFiscale::from($variant))->value())->toBe('RSSMRA95E05F205Z');
+})->with([
+    'level 1' => ['RSSMRA95E05F20RU'],
+    'level 2' => ['RSSMRA95E05F2LRF'],
+    'level 3' => ['RSSMRA95E05FNLRU'],
+    'level 4' => ['RSSMRA95E0RFNLRP'],
+    'level 5' => ['RSSMRA95ELRFNLRA'],
+    'level 6' => ['RSSMRA9RELRFNLRM'],
+    'level 7 (all positions substituted)' => ['RSSMRAVRELRFNLRB'],
+]);
+
+test('level() counts how many of the 7 eligible positions are letter-substituted', function (string $code, int $expectedLevel) {
+    expect((new Omocodia())->level(CodiceFiscale::from($code)))->toBe($expectedLevel);
+})->with([
+    'level 0 (canonical)' => ['RSSMRA95E05F205Z', 0],
+    'level 1' => ['RSSMRA95E05F20RU', 1],
+    'level 2' => ['RSSMRA95E05F2LRF', 2],
+    'level 3' => ['RSSMRA95E05FNLRU', 3],
+    'level 4' => ['RSSMRA95E0RFNLRP', 4],
+    'level 5' => ['RSSMRA95ELRFNLRA', 5],
+    'level 6' => ['RSSMRA9RELRFNLRM', 6],
+    'level 7' => ['RSSMRAVRELRFNLRB', 7],
+]);
+
+test('variants() returns exactly 128 items, every one checksum-correct', function () {
+    $canonical = CodiceFiscale::from('RSSMRA95E05F205Z');
+    $checksum = new Checksum();
+
+    $variants = iterator_to_array((new Omocodia())->variants($canonical));
+
+    expect($variants)->toHaveCount(128);
+
+    foreach ($variants as $variant) {
+        expect($checksum->verify($variant->value()))->toBeTrue();
+    }
+});
+
+test('variants() are all distinct', function () {
+    $canonical = CodiceFiscale::from('RSSMRA95E05F205Z');
+
+    $values = array_map(
+        fn ($variant) => $variant->value(),
+        iterator_to_array((new Omocodia())->variants($canonical))
+    );
+
+    expect(array_unique($values))->toHaveCount(128);
+});
+
+test('variants() includes the canonical form itself and the known real omocodia fixtures', function () {
+    $canonical = CodiceFiscale::from('RSSMRA95E05F205Z');
+
+    $values = array_map(
+        fn ($variant) => $variant->value(),
+        iterator_to_array((new Omocodia())->variants($canonical))
+    );
+
+    expect($values)->toContain('RSSMRA95E05F205Z')
+        ->toContain('RSSMRA95E05F20RU')
+        ->toContain('RSSMRAVRELRFNLRB');
+});
+
+test('canonical() of every variant returns the original canonical code', function () {
+    $canonical = CodiceFiscale::from('RSSMRA95E05F205Z');
+    $omocodia = new Omocodia();
+
+    foreach ($omocodia->variants($canonical) as $variant) {
+        expect($omocodia->canonical($variant)->value())->toBe('RSSMRA95E05F205Z');
+    }
+});
+
+test('variants() called on a non-canonical variant still enumerates the same 128-member set', function () {
+    $fromVariant = iterator_to_array((new Omocodia())->variants(CodiceFiscale::from('RSSMRA95E05F20RU')));
+    $fromCanonical = iterator_to_array((new Omocodia())->variants(CodiceFiscale::from('RSSMRA95E05F205Z')));
+
+    $valuesOf = fn (array $codes) => array_map(fn ($c) => $c->value(), $codes);
+
+    expect($valuesOf($fromVariant))->toEqualCanonicalizing($valuesOf($fromCanonical));
+});


### PR DESCRIPTION
Closes #80.

## Summary
- `Omocodia::canonical()` — pure, mechanical reversal of letter substitutions back to digits across the 7 eligible positions. No repository/generator dependency.
- `Omocodia::variants()` — the full 2⁷ = 128-member cartesian product (each position independently digit-or-letter), matching the real Agenzia delle Entrate algorithm rather than a cumulative level.
- `Omocodia::level()` — count of substituted positions (0-7); docblock explicitly disclaims any ordinal/cumulative reading per `CONTEXT.md`'s definition.
- `CodiceFiscale::isEquivalentTo()` — compares canonical forms, delegating to `Omocodia` internally.

## Test plan
- [x] 113 Pest tests passing (647 assertions), including an exhaustive check that `isEquivalentTo()` holds against all 128 variants (not just one)
- [x] Fixtures: levels 0/1 are real values recovered from the deleted 2.x suite; levels 2-7 are constructed by substituting an increasing prefix of the 7 eligible positions and computing each checksum via the already-verified `Checksum` service, not by running this ticket's own code
- [x] PHPStan level max passes clean
- [x] `php-cs-fixer --dry-run` passes
- [x] Reviewed via `/code-review` (Standards + Spec axes) — two fixes applied (AC4 exhaustiveness gap, `level()` docblock clarification + minor dedup); mutual `CodiceFiscale`↔`Omocodia` coupling flagged and confirmed as a deliberate, spec-mandated tradeoff rather than an oversight