### PR TITLE
Parser + century resolution

### DIFF
--- a/src/Contracts/CenturyResolver.php
+++ b/src/Contracts/CenturyResolver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Contracts;
+
+interface CenturyResolver
+{
+    /**
+     * @param  array{int, int}  $possibleYears  exactly two 4-digit
+     *                                          candidate years 100 years apart, e.g. [1926, 2026]
+     */
+    public function resolve(array $possibleYears): int;
+}

--- a/src/Generation/DateEncoder.php
+++ b/src/Generation/DateEncoder.php
@@ -6,7 +6,12 @@ use Robertogallea\CodiceFiscale\Enums\Gender;
 
 final class DateEncoder
 {
-    private const MONTH_LETTERS = [
+    /**
+     * The single source of truth for the month letter table - also
+     * referenced by Parser to decode a letter back into a month
+     * number, so a correction here propagates to both directions.
+     */
+    public const MONTH_LETTERS = [
         1 => 'A', 2 => 'B', 3 => 'C', 4 => 'D', 5 => 'E',
         6 => 'H', 7 => 'L', 8 => 'M', 9 => 'P', 10 => 'R',
         11 => 'S', 12 => 'T',

--- a/src/Parsing/Century/AgeBasedCenturyResolver.php
+++ b/src/Parsing/Century/AgeBasedCenturyResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Parsing\Century;
+
+use Robertogallea\CodiceFiscale\Contracts\CenturyResolver;
+
+/**
+ * Resolves a codice fiscale's century ambiguity by preferring the
+ * most recent candidate year that isn't in the future and doesn't
+ * imply an age over maxAge - i.e. the youngest plausible reading.
+ * When neither candidate is plausible (an unusually small maxAge),
+ * falls back to the more recent one anyway, as the least-bad choice.
+ */
+final readonly class AgeBasedCenturyResolver implements CenturyResolver
+{
+    public function __construct(
+        private int $maxAge = 120,
+        private ?\DateTimeImmutable $referenceDate = null,
+    ) {
+    }
+
+    public function resolve(array $possibleYears): int
+    {
+        $currentYear = (int) ($this->referenceDate ?? new \DateTimeImmutable('today'))->format('Y');
+
+        $plausible = array_values(array_filter(
+            $possibleYears,
+            fn (int $year): bool => $year <= $currentYear && ($currentYear - $year) <= $this->maxAge
+        ));
+
+        return $plausible !== [] ? max($plausible) : max($possibleYears);
+    }
+}

--- a/src/Parsing/ParsedCodiceFiscale.php
+++ b/src/Parsing/ParsedCodiceFiscale.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Parsing;
+
+use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Contracts\CenturyResolver;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+
+final readonly class ParsedCodiceFiscale
+{
+    public function __construct(
+        private string $surnameCode,
+        private string $nameCode,
+        private int $birthYearCode,
+        private int $birthMonthNumber,
+        private int $birthDay,
+        private Gender $gender,
+        private BirthPlaceCode $birthPlaceCode,
+        private bool $isOmocodia,
+        private BirthPlaceRepository $birthPlaceRepository,
+        private CenturyResolver $centuryResolver,
+    ) {
+    }
+
+    public function surnameCode(): string
+    {
+        return $this->surnameCode;
+    }
+
+    public function nameCode(): string
+    {
+        return $this->nameCode;
+    }
+
+    public function gender(): Gender
+    {
+        return $this->gender;
+    }
+
+    public function birthMonth(): int
+    {
+        return $this->birthMonthNumber;
+    }
+
+    public function birthDay(): int
+    {
+        return $this->birthDay;
+    }
+
+    public function birthPlaceCode(): BirthPlaceCode
+    {
+        return $this->birthPlaceCode;
+    }
+
+    public function isOmocodia(): bool
+    {
+        return $this->isOmocodia;
+    }
+
+    /** @return array{int, int} */
+    public function possibleBirthYears(): array
+    {
+        return [1900 + $this->birthYearCode, 2000 + $this->birthYearCode];
+    }
+
+    public function birthYear(): int
+    {
+        return $this->centuryResolver->resolve($this->possibleBirthYears());
+    }
+
+    public function birthDate(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable(sprintf(
+            '%04d-%02d-%02d',
+            $this->birthYear(),
+            $this->birthMonthNumber,
+            $this->birthDay,
+        ));
+    }
+
+    public function birthPlace(): ?BirthPlace
+    {
+        return $this->birthPlaceRepository->find($this->birthPlaceCode, $this->birthDate());
+    }
+}

--- a/src/Parsing/ParsedCodiceFiscale.php
+++ b/src/Parsing/ParsedCodiceFiscale.php
@@ -70,18 +70,28 @@ final readonly class ParsedCodiceFiscale
         return $this->centuryResolver->resolve($this->possibleBirthYears());
     }
 
-    public function birthDate(): \DateTimeImmutable
+    /**
+     * Null when the decoded month/day don't form a real calendar date
+     * (e.g. a checksum-invalid or otherwise nonsense code) - decoding
+     * never throws for data it doesn't recognize as sensible, the
+     * same way birthPlace() returns null rather than throwing for an
+     * unrecognized code.
+     */
+    public function birthDate(): ?\DateTimeImmutable
     {
-        return new \DateTimeImmutable(sprintf(
-            '%04d-%02d-%02d',
-            $this->birthYear(),
-            $this->birthMonthNumber,
-            $this->birthDay,
-        ));
+        $year = $this->birthYear();
+
+        if (! checkdate($this->birthMonthNumber, $this->birthDay, $year)) {
+            return null;
+        }
+
+        return new \DateTimeImmutable(sprintf('%04d-%02d-%02d', $year, $this->birthMonthNumber, $this->birthDay));
     }
 
     public function birthPlace(): ?BirthPlace
     {
-        return $this->birthPlaceRepository->find($this->birthPlaceCode, $this->birthDate());
+        $birthDate = $this->birthDate();
+
+        return $birthDate === null ? null : $this->birthPlaceRepository->find($this->birthPlaceCode, $birthDate);
     }
 }

--- a/src/Parsing/Parser.php
+++ b/src/Parsing/Parser.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Parsing;
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Contracts\CenturyResolver;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Omocodia\Omocodia;
+use Robertogallea\CodiceFiscale\Parsing\Century\AgeBasedCenturyResolver;
+
+final class Parser
+{
+    private const MONTH_LETTER_TO_NUMBER = [
+        'A' => 1, 'B' => 2, 'C' => 3, 'D' => 4, 'E' => 5,
+        'H' => 6, 'L' => 7, 'M' => 8, 'P' => 9, 'R' => 10,
+        'S' => 11, 'T' => 12,
+    ];
+
+    public function __construct(
+        private readonly BirthPlaceRepository $birthPlaceRepository,
+        private readonly CenturyResolver $centuryResolver = new AgeBasedCenturyResolver(maxAge: 120),
+        private readonly Omocodia $omocodia = new Omocodia(),
+    ) {
+    }
+
+    public function parse(CodiceFiscale $cf): ParsedCodiceFiscale
+    {
+        // De-omocodize first: the 7 eligible positions might hold a
+        // letter instead of a digit, and every numeric field below
+        // (year, day, birthplace digits) needs the real digit.
+        $canonical = $this->omocodia->canonical($cf)->value();
+
+        $rawDay = (int) substr($canonical, 9, 2);
+        $gender = $rawDay > 40 ? Gender::Female : Gender::Male;
+
+        return new ParsedCodiceFiscale(
+            surnameCode: substr($canonical, 0, 3),
+            nameCode: substr($canonical, 3, 3),
+            birthYearCode: (int) substr($canonical, 6, 2),
+            birthMonthNumber: self::MONTH_LETTER_TO_NUMBER[$canonical[8]],
+            birthDay: $gender === Gender::Female ? $rawDay - 40 : $rawDay,
+            gender: $gender,
+            birthPlaceCode: BirthPlaceCode::from(substr($canonical, 11, 4)),
+            isOmocodia: $this->omocodia->level($cf) > 0,
+            birthPlaceRepository: $this->birthPlaceRepository,
+            centuryResolver: $this->centuryResolver,
+        );
+    }
+}

--- a/src/Parsing/Parser.php
+++ b/src/Parsing/Parser.php
@@ -7,17 +7,12 @@ use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
 use Robertogallea\CodiceFiscale\Contracts\CenturyResolver;
 use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
 use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Generation\DateEncoder;
 use Robertogallea\CodiceFiscale\Omocodia\Omocodia;
 use Robertogallea\CodiceFiscale\Parsing\Century\AgeBasedCenturyResolver;
 
 final class Parser
 {
-    private const MONTH_LETTER_TO_NUMBER = [
-        'A' => 1, 'B' => 2, 'C' => 3, 'D' => 4, 'E' => 5,
-        'H' => 6, 'L' => 7, 'M' => 8, 'P' => 9, 'R' => 10,
-        'S' => 11, 'T' => 12,
-    ];
-
     public function __construct(
         private readonly BirthPlaceRepository $birthPlaceRepository,
         private readonly CenturyResolver $centuryResolver = new AgeBasedCenturyResolver(maxAge: 120),
@@ -25,6 +20,13 @@ final class Parser
     ) {
     }
 
+    /**
+     * Field layout of the canonical (de-omocodized) 16-character
+     * string, matching CodiceFiscale::STRUCTURE_PATTERN's own
+     * breakdown: 3 surname-code letters (0-2), 3 name-code letters
+     * (3-5), 2 year digits (6-7), 1 month letter (8), 2 day digits
+     * (9-10), then the 4-character birthplace code (11-14).
+     */
     public function parse(CodiceFiscale $cf): ParsedCodiceFiscale
     {
         // De-omocodize first: the 7 eligible positions might hold a
@@ -39,7 +41,9 @@ final class Parser
             surnameCode: substr($canonical, 0, 3),
             nameCode: substr($canonical, 3, 3),
             birthYearCode: (int) substr($canonical, 6, 2),
-            birthMonthNumber: self::MONTH_LETTER_TO_NUMBER[$canonical[8]],
+            // CodiceFiscale::STRUCTURE_PATTERN already guarantees position 8
+            // is one of the 12 valid month letters, so this is always found.
+            birthMonthNumber: (int) array_search($canonical[8], DateEncoder::MONTH_LETTERS, true),
             birthDay: $gender === Gender::Female ? $rawDay - 40 : $rawDay,
             gender: $gender,
             birthPlaceCode: BirthPlaceCode::from(substr($canonical, 11, 4)),

--- a/tests/Unit/AgeBasedCenturyResolverTest.php
+++ b/tests/Unit/AgeBasedCenturyResolverTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Parsing\Century\AgeBasedCenturyResolver;
+
+test('prefers the more recent candidate when both are within maxAge and not in the future', function () {
+    $resolver = new AgeBasedCenturyResolver(maxAge: 120, referenceDate: new DateTimeImmutable('2026-08-09'));
+
+    // 1926 (age 100) and 2026 (age 0) are both plausible; prefer the younger reading.
+    expect($resolver->resolve([1926, 2026]))->toBe(2026);
+});
+
+test('picks the only plausible candidate when the other is in the future', function () {
+    $resolver = new AgeBasedCenturyResolver(maxAge: 120, referenceDate: new DateTimeImmutable('2005-01-01'));
+
+    // 1926 (age 79) is plausible; 2026 is in the future and excluded outright.
+    expect($resolver->resolve([1926, 2026]))->toBe(1926);
+});
+
+test('picks the only plausible candidate when the other would exceed maxAge', function () {
+    $resolver = new AgeBasedCenturyResolver(maxAge: 50, referenceDate: new DateTimeImmutable('2026-08-09'));
+
+    // 1926 (age 100) exceeds maxAge 50; 2026 (age 0) is the only plausible reading.
+    expect($resolver->resolve([1926, 2026]))->toBe(2026);
+});
+
+test('falls back to the more recent candidate when neither is plausible', function () {
+    $resolver = new AgeBasedCenturyResolver(maxAge: 5, referenceDate: new DateTimeImmutable('1975-01-01'));
+
+    // 1926 (age 49) exceeds maxAge 5; 2026 is in the future. Neither is
+    // plausible, so the more recent candidate is the least-bad fallback.
+    expect($resolver->resolve([1926, 2026]))->toBe(2026);
+});
+
+test('defaults to today when no reference date is given', function () {
+    $resolver = new AgeBasedCenturyResolver(maxAge: 120);
+
+    $currentYear = (int) (new DateTimeImmutable('today'))->format('Y');
+    $twoDigitYear = (int) substr((string) $currentYear, -2);
+
+    expect($resolver->resolve([1900 + $twoDigitYear, 2000 + $twoDigitYear]))->toBe(2000 + $twoDigitYear);
+});

--- a/tests/Unit/CodiceFiscaleTest.php
+++ b/tests/Unit/CodiceFiscaleTest.php
@@ -47,10 +47,12 @@ test('tryFrom() returns null for the same malformed input instead of throwing', 
 ]);
 
 test('has no dependency on checksum validity', function () {
-    // RSSMRA95E05F205A has an incorrect check character (the real one is Z),
-    // yet construction succeeds — checksum correctness is exclusively the
-    // Validator's concern, not the value object's.
-    expect(fn () => CodiceFiscale::from('RSSMRA95E05F205A'))->not->toThrow(Throwable::class);
+    // RSSMRA95E05F205A has an incorrect check character (the real one is Z).
+    // Calling from() directly (rather than via toThrow()) means this test
+    // fails loudly with an uncaught exception if construction ever starts
+    // rejecting it — checksum correctness is exclusively the Validator's
+    // concern, not the value object's.
+    expect(CodiceFiscale::from('RSSMRA95E05F205A')->value())->toBe('RSSMRA95E05F205A');
 });
 
 test('casts to string as its value', function () {

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -120,23 +120,29 @@ test('birthPlace() resolves the era-record valid on the parsed birth date', func
         ->and($parser->parse($bornUnderLodi)->birthPlace()->province())->toBe('LO');
 });
 
-test('never throws for structurally-fine-but-nonsense data - only CodiceFiscale::from() rejects malformed input', function (string $code) {
+test('never throws for a nonsense birthplace code - birthPlace() returns null, birthDate() is still valid', function () {
     $parser = new Parser(new InMemoryBirthPlaceRepository());
 
-    $parsed = null;
-    expect(function () use ($parser, $code, &$parsed) {
-        $parsed = $parser->parse(CodiceFiscale::from($code));
-    })->not->toThrow(Throwable::class);
+    // Every call below runs to completion and returns a real value;
+    // if any of them threw, this test would fail with an uncaught
+    // exception rather than silently pass.
+    $parsed = $parser->parse(CodiceFiscale::from('LNEGLI94D20A000X'));
 
-    // Fully exercise every method, including the ones that touch the
-    // repository or build a DateTimeImmutable, not just parse() itself.
-    expect(fn () => [
-        $parsed->birthPlaceCode(),
-        $parsed->birthPlace(),
-        $parsed->birthDate(),
-        $parsed->birthYear(),
-    ])->not->toThrow(Throwable::class);
-})->with([
-    'nonsense birthplace code' => ['LNEGLI94D20A000X'],
-    'nonexistent calendar date (day 77)' => ['LOIMLC71A77F979V'],
-]);
+    expect($parsed->birthPlaceCode()->value())->toBe('A000')
+        ->and($parsed->birthPlace())->toBeNull()
+        ->and($parsed->birthDate())->toEqual(new DateTimeImmutable('1994-04-20'));
+});
+
+test('never throws for a nonexistent calendar date - birthDate() and birthPlace() return null instead', function () {
+    $parser = new Parser(new InMemoryBirthPlaceRepository());
+
+    // Raw day 77 -> female (>40), day 77-40 = 37, not a real day of
+    // any month. Every call below runs to completion; if parse() or
+    // any accessor threw, this test would fail with an uncaught
+    // exception, not silently pass.
+    $parsed = $parser->parse(CodiceFiscale::from('LOIMLC71A77F979V'));
+
+    expect($parsed->birthDay())->toBe(37)
+        ->and($parsed->birthDate())->toBeNull()
+        ->and($parsed->birthPlace())->toBeNull();
+});

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Contracts\CenturyResolver;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\Person;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Generation\Generator;
+use Robertogallea\CodiceFiscale\Parsing\Parser;
+use Tests\Support\InMemoryBirthPlaceRepository;
+
+test('decodes surname code, name code, gender, month, day and birthplace code', function () {
+    $parser = new Parser(new InMemoryBirthPlaceRepository());
+    $parsed = $parser->parse(CodiceFiscale::from('RSSMRA95E05F205Z'));
+
+    expect($parsed->surnameCode())->toBe('RSS')
+        ->and($parsed->nameCode())->toBe('MRA')
+        ->and($parsed->gender())->toBe(Gender::Male)
+        ->and($parsed->birthMonth())->toBe(5)
+        ->and($parsed->birthDay())->toBe(5)
+        ->and($parsed->birthPlaceCode()->value())->toBe('F205')
+        ->and($parsed->isOmocodia())->toBeFalse();
+});
+
+test('decodes an omocodia variant to the same fields as its canonical form', function () {
+    $parser = new Parser(new InMemoryBirthPlaceRepository());
+    $parsed = $parser->parse(CodiceFiscale::from('RSSMRA95E05F20RU'));
+
+    expect($parsed->surnameCode())->toBe('RSS')
+        ->and($parsed->nameCode())->toBe('MRA')
+        ->and($parsed->gender())->toBe(Gender::Male)
+        ->and($parsed->birthMonth())->toBe(5)
+        ->and($parsed->birthDay())->toBe(5)
+        ->and($parsed->birthPlaceCode()->value())->toBe('F205')
+        ->and($parsed->isOmocodia())->toBeTrue();
+});
+
+test('decodes a female code, subtracting the 40-day offset', function () {
+    $parser = new Parser(new InMemoryBirthPlaceRepository());
+    $parsed = $parser->parse(CodiceFiscale::from('RSSMRA95E45F205D'));
+
+    expect($parsed->gender())->toBe(Gender::Female)
+        ->and($parsed->birthDay())->toBe(5);
+});
+
+test('decodes an internationally-birthplaced code correctly', function () {
+    $parser = new Parser(new InMemoryBirthPlaceRepository());
+    $parsed = $parser->parse(CodiceFiscale::from('RBRRHR93L09Z357P'));
+
+    // Position 8 is 'L' -> month 7 (July), per the month-letter table.
+    expect($parsed->birthPlaceCode()->value())->toBe('Z357')
+        ->and($parsed->birthPlaceCode()->isForeign())->toBeTrue()
+        ->and($parsed->birthMonth())->toBe(7)
+        ->and($parsed->birthDay())->toBe(9);
+});
+
+test('possibleBirthYears() exposes both century candidates for the ambiguous 2-digit year', function () {
+    $parser = new Parser(new InMemoryBirthPlaceRepository());
+    $parsed = $parser->parse(CodiceFiscale::from('RSSMRA95E05F205Z'));
+
+    expect($parsed->possibleBirthYears())->toBe([1995, 2095]);
+});
+
+test('birthDate() resolves via the default AgeBasedCenturyResolver when none is injected', function () {
+    $parser = new Parser(new InMemoryBirthPlaceRepository());
+    $parsed = $parser->parse(CodiceFiscale::from('RSSMRA95E05F205Z'));
+
+    // 2095 is always in the future relative to when this test runs;
+    // only 1995 is ever plausible, so this is deterministic without
+    // needing to inject a reference date.
+    expect($parsed->birthYear())->toBe(1995)
+        ->and($parsed->birthDate())->toEqual(new DateTimeImmutable('1995-05-05'));
+});
+
+test('a custom CenturyResolver is used instead of the default', function () {
+    $alwaysPicksTheFutureCentury = new class implements CenturyResolver {
+        public function resolve(array $possibleYears): int
+        {
+            return max($possibleYears);
+        }
+    };
+
+    $parser = new Parser(new InMemoryBirthPlaceRepository(), $alwaysPicksTheFutureCentury);
+    $parsed = $parser->parse(CodiceFiscale::from('RSSMRA95E05F205Z'));
+
+    expect($parsed->birthYear())->toBe(2095);
+});
+
+test('birthPlace() returns null - not an exception - for an unrecognized code', function () {
+    $parser = new Parser(new InMemoryBirthPlaceRepository());
+    $parsed = $parser->parse(CodiceFiscale::from('RSSMRA95E05F205Z'));
+
+    expect($parsed->birthPlace())->toBeNull();
+});
+
+test('birthPlace() resolves the era-record valid on the parsed birth date', function () {
+    $repository = new InMemoryBirthPlaceRepository(
+        abbadiaCerretoUnderMilano(),
+        abbadiaCerretoUnderLodi(),
+    );
+    $parser = new Parser($repository);
+    $generator = new Generator();
+
+    $bornUnderMilano = $generator->generate(new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1950-01-01'),
+        birthPlace: BirthPlaceCode::from('A004'),
+        gender: Gender::Male,
+    ));
+    $bornUnderLodi = $generator->generate(new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('2000-01-01'),
+        birthPlace: BirthPlaceCode::from('A004'),
+        gender: Gender::Male,
+    ));
+
+    expect($parser->parse($bornUnderMilano)->birthPlace()->province())->toBe('MI')
+        ->and($parser->parse($bornUnderLodi)->birthPlace()->province())->toBe('LO');
+});
+
+test('never throws for structurally-fine-but-nonsense data - only CodiceFiscale::from() rejects malformed input', function (string $code) {
+    $parser = new Parser(new InMemoryBirthPlaceRepository());
+
+    $parsed = null;
+    expect(function () use ($parser, $code, &$parsed) {
+        $parsed = $parser->parse(CodiceFiscale::from($code));
+    })->not->toThrow(Throwable::class);
+
+    // Fully exercise every method, including the ones that touch the
+    // repository or build a DateTimeImmutable, not just parse() itself.
+    expect(fn () => [
+        $parsed->birthPlaceCode(),
+        $parsed->birthPlace(),
+        $parsed->birthDate(),
+        $parsed->birthYear(),
+    ])->not->toThrow(Throwable::class);
+})->with([
+    'nonsense birthplace code' => ['LNEGLI94D20A000X'],
+    'nonexistent calendar date (day 77)' => ['LOIMLC71A77F979V'],
+]);


### PR DESCRIPTION
Closes #81.

## Summary
- `Parser::parse(CodiceFiscale): ParsedCodiceFiscale` — de-omocodizes via `Omocodia::canonical()` first, then decodes surname/name codes, gender, month, day, and birthplace code from the guaranteed-digit canonical form.
- `birthPlace()` resolves through the repository using the **parsed birth date** as the `on` parameter (not today's date) — verified against the real Abbadia Cerreto province-change fixture on both sides of the 1992 boundary.
- `CenturyResolver` contract + `AgeBasedCenturyResolver(maxAge: 120)` default: prefers the youngest plausible reading, falling back to the more recent candidate when neither is plausible. `possibleBirthYears()` exposes the raw two-candidate ambiguity.
- `birthDate()` returns `null` (not throwing) for a structurally-fine-but-calendrically-impossible date, matching `birthPlace()`'s existing "return null for unrecognized data" pattern — see review fixes below.

## Review-caught bug (important)
The first pass had a real AC5 violation: `birthDate()` threw `DateMalformedStringException` for a nonexistent calendar date (e.g. day 77 → 37). The test meant to catch this was a false negative — Pest's `toThrow(Throwable::class)` silently no-ops for interface arguments (`class_exists('Throwable')` is `false`), so it "passed" regardless of what was actually thrown. Verified both the real bug and the broken matcher independently before fixing. `birthDate()` is now nullable via `checkdate()`; the test now asserts real return values directly instead of relying on `toThrow()`. Also fixed the same latent footgun in `CodiceFiscaleTest.php` from #77 (harmless there, but same pattern).

## Test plan
- [x] 129 Pest tests passing (685 assertions)
- [x] PHPStan level max passes clean
- [x] `php-cs-fixer --dry-run` passes
- [x] Reviewed via `/code-review` (Standards + Spec axes) — one real bug found and fixed (see above), plus minor dedup (Parser no longer hand-maintains its own copy of `DateEncoder`'s month-letter table) and a layout docblock cross-referencing `CodiceFiscale::STRUCTURE_PATTERN`