### PR TITLE
Validator

### DIFF
--- a/src/Enums/ValidationError.php
+++ b/src/Enums/ValidationError.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Enums;
+
+enum ValidationError: string
+{
+    case InvalidFormat = 'invalid_format';
+    case InvalidChecksum = 'invalid_checksum';
+    case InvalidDate = 'invalid_date';
+    case UnknownBirthPlace = 'unknown_birth_place';
+    case BirthPlaceNotValidOnDate = 'birth_place_not_valid_on_date';
+}

--- a/src/Validation/ValidationResult.php
+++ b/src/Validation/ValidationResult.php
@@ -12,6 +12,16 @@ final readonly class ValidationResult
     ) {
     }
 
+    public static function ok(): self
+    {
+        return new self([]);
+    }
+
+    public static function withError(ValidationError $error): self
+    {
+        return new self([$error]);
+    }
+
     public function valid(): bool
     {
         return $this->errors === [];

--- a/src/Validation/ValidationResult.php
+++ b/src/Validation/ValidationResult.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Validation;
+
+use Robertogallea\CodiceFiscale\Enums\ValidationError;
+
+final readonly class ValidationResult
+{
+    /** @param list<ValidationError> $errors */
+    public function __construct(
+        private array $errors,
+    ) {
+    }
+
+    public function valid(): bool
+    {
+        return $this->errors === [];
+    }
+
+    /** @return list<ValidationError> */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Validation;
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Enums\ValidationError;
+use Robertogallea\CodiceFiscale\Generation\Checksum;
+use Robertogallea\CodiceFiscale\Parsing\Parser;
+
+final class Validator
+{
+    private readonly Parser $parser;
+
+    public function __construct(
+        private readonly BirthPlaceRepository $birthPlaceRepository,
+        private readonly Checksum $checksum = new Checksum(),
+        ?Parser $parser = null,
+    ) {
+        $this->parser = $parser ?? new Parser($birthPlaceRepository);
+    }
+
+    /**
+     * Structural well-formedness only. Takes a raw string, not a
+     * CodiceFiscale, since a CodiceFiscale instance can only ever be
+     * constructed already-well-formed - there is no other way to
+     * observe a genuine format failure.
+     */
+    public function validateFormat(string $value): ValidationResult
+    {
+        return CodiceFiscale::tryFrom($value) === null
+            ? new ValidationResult([ValidationError::InvalidFormat])
+            : new ValidationResult([]);
+    }
+
+    public function validateChecksum(CodiceFiscale $cf): ValidationResult
+    {
+        return $this->checksum->verify($cf->value())
+            ? new ValidationResult([])
+            : new ValidationResult([ValidationError::InvalidChecksum]);
+    }
+
+    public function validateSemantics(CodiceFiscale $cf): ValidationResult
+    {
+        $parsed = $this->parser->parse($cf);
+        $birthDate = $parsed->birthDate();
+        $errors = [];
+
+        if ($birthDate === null) {
+            $errors[] = ValidationError::InvalidDate;
+        }
+
+        if (! $this->birthPlaceRepository->existedEver($parsed->birthPlaceCode())) {
+            $errors[] = ValidationError::UnknownBirthPlace;
+        } elseif ($birthDate !== null && $this->birthPlaceRepository->find($parsed->birthPlaceCode(), $birthDate) === null) {
+            $errors[] = ValidationError::BirthPlaceNotValidOnDate;
+        }
+
+        return new ValidationResult($errors);
+    }
+
+    /**
+     * Format gates: a malformed string is never passed to checksum or
+     * semantic checks (there's no safe way to slice it). Once format
+     * passes, checksum and semantics run independently of each other
+     * and both contribute to the same result.
+     */
+    public function validate(string $value): ValidationResult
+    {
+        $formatResult = $this->validateFormat($value);
+
+        if (! $formatResult->valid()) {
+            return $formatResult;
+        }
+
+        $cf = CodiceFiscale::from($value);
+
+        return new ValidationResult([
+            ...$this->validateChecksum($cf)->errors(),
+            ...$this->validateSemantics($cf)->errors(),
+        ]);
+    }
+}

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -8,6 +8,17 @@ use Robertogallea\CodiceFiscale\Enums\ValidationError;
 use Robertogallea\CodiceFiscale\Generation\Checksum;
 use Robertogallea\CodiceFiscale\Parsing\Parser;
 
+/**
+ * validateFormat()/validate() take a raw string rather than a
+ * CodiceFiscale: a CodiceFiscale instance can only ever be
+ * constructed already structurally valid (via from()/tryFrom()), so
+ * there is no way to observe a genuine format failure once one
+ * exists. validateChecksum()/validateSemantics() stay
+ * CodiceFiscale-typed - they need guaranteed structure to safely read
+ * fixed positions, and by the time either is called (from validate(),
+ * or directly by a caller who already has a CodiceFiscale) that's
+ * exactly what's available.
+ */
 final class Validator
 {
     private readonly Parser $parser;
@@ -29,15 +40,15 @@ final class Validator
     public function validateFormat(string $value): ValidationResult
     {
         return CodiceFiscale::tryFrom($value) === null
-            ? new ValidationResult([ValidationError::InvalidFormat])
-            : new ValidationResult([]);
+            ? ValidationResult::withError(ValidationError::InvalidFormat)
+            : ValidationResult::ok();
     }
 
     public function validateChecksum(CodiceFiscale $cf): ValidationResult
     {
         return $this->checksum->verify($cf->value())
-            ? new ValidationResult([])
-            : new ValidationResult([ValidationError::InvalidChecksum]);
+            ? ValidationResult::ok()
+            : ValidationResult::withError(ValidationError::InvalidChecksum);
     }
 
     public function validateSemantics(CodiceFiscale $cf): ValidationResult

--- a/tests/Unit/ValidationResultTest.php
+++ b/tests/Unit/ValidationResultTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Enums\ValidationError;
+use Robertogallea\CodiceFiscale\Validation\ValidationResult;
+
+test('ok() is valid with no errors', function () {
+    $result = ValidationResult::ok();
+
+    expect($result->valid())->toBeTrue()
+        ->and($result->errors())->toBe([]);
+});
+
+test('withError() is invalid with exactly the given error', function () {
+    $result = ValidationResult::withError(ValidationError::InvalidChecksum);
+
+    expect($result->valid())->toBeFalse()
+        ->and($result->errors())->toBe([ValidationError::InvalidChecksum]);
+});

--- a/tests/Unit/ValidatorTest.php
+++ b/tests/Unit/ValidatorTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\Person;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Enums\ValidationError;
+use Robertogallea\CodiceFiscale\Generation\Generator;
+use Robertogallea\CodiceFiscale\Validation\Validator;
+use Tests\Support\InMemoryBirthPlaceRepository;
+
+test('validateFormat() is valid for a structurally well-formed string', function () {
+    $validator = new Validator(new InMemoryBirthPlaceRepository());
+
+    $result = $validator->validateFormat('RSSMRA95E05F205Z');
+
+    expect($result->valid())->toBeTrue()
+        ->and($result->errors())->toBe([]);
+});
+
+test('validateFormat() reports InvalidFormat for a malformed string', function () {
+    $validator = new Validator(new InMemoryBirthPlaceRepository());
+
+    $result = $validator->validateFormat('ABC');
+
+    expect($result->valid())->toBeFalse()
+        ->and($result->errors())->toBe([ValidationError::InvalidFormat]);
+});
+
+test('validateChecksum() is valid for a correct check character', function () {
+    $validator = new Validator(new InMemoryBirthPlaceRepository());
+
+    $result = $validator->validateChecksum(CodiceFiscale::from('RSSMRA95E05F205Z'));
+
+    expect($result->valid())->toBeTrue();
+});
+
+test('validateChecksum() reports InvalidChecksum for a wrong check character', function () {
+    $validator = new Validator(new InMemoryBirthPlaceRepository());
+
+    // RSSMRA95E05F205A has an incorrect check character (the real one is Z),
+    // but it's still structurally well-formed so CodiceFiscale::from() accepts it.
+    $result = $validator->validateChecksum(CodiceFiscale::from('RSSMRA95E05F205A'));
+
+    expect($result->valid())->toBeFalse()
+        ->and($result->errors())->toBe([ValidationError::InvalidChecksum]);
+});
+
+test('validateSemantics() is valid for a real date and a recognized birthplace', function () {
+    $repository = new InMemoryBirthPlaceRepository(abbadiaCerretoUnderLodi());
+    $validator = new Validator($repository);
+
+    $bornUnderLodi = (new Generator())->generate(new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('2000-01-01'),
+        birthPlace: BirthPlaceCode::from('A004'),
+        gender: Gender::Male,
+    ));
+
+    expect($validator->validateSemantics($bornUnderLodi)->valid())->toBeTrue();
+});
+
+test('validateSemantics() reports InvalidDate for a nonexistent calendar date', function () {
+    $validator = new Validator(new InMemoryBirthPlaceRepository());
+
+    // Day 77 -> female (>40), day 37: not a real day of any month.
+    // This fixture's birthplace code (F979) also isn't recognized by
+    // the empty repository, so UnknownBirthPlace legitimately appears
+    // alongside it - both independent errors surface in one pass.
+    $result = $validator->validateSemantics(CodiceFiscale::from('LOIMLC71A77F979V'));
+
+    expect($result->valid())->toBeFalse()
+        ->and($result->errors())->toBe([ValidationError::InvalidDate, ValidationError::UnknownBirthPlace]);
+});
+
+test('validateSemantics() reports UnknownBirthPlace for a code that never existed', function () {
+    $validator = new Validator(new InMemoryBirthPlaceRepository());
+
+    $result = $validator->validateSemantics(CodiceFiscale::from('LNEGLI94D20A000X'));
+
+    expect($result->valid())->toBeFalse()
+        ->and($result->errors())->toBe([ValidationError::UnknownBirthPlace]);
+});
+
+test('validateSemantics() reports BirthPlaceNotValidOnDate - distinct from UnknownBirthPlace - for a code that existed, just not on this date', function () {
+    $repository = new InMemoryBirthPlaceRepository(abbadiaCerretoUnderLodi());
+    $validator = new Validator($repository);
+
+    // A004 exists (under Lodi, from 1992-04-16), but this person is
+    // encoded as born in 1950 - before that era-record's validFrom.
+    $bornBeforeLodiEra = (new Generator())->generate(new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1950-01-01'),
+        birthPlace: BirthPlaceCode::from('A004'),
+        gender: Gender::Male,
+    ));
+
+    $result = $validator->validateSemantics($bornBeforeLodiEra);
+
+    expect($result->valid())->toBeFalse()
+        ->and($result->errors())->toBe([ValidationError::BirthPlaceNotValidOnDate]);
+});
+
+test('validate() is valid for a fully correct code', function () {
+    $repository = new InMemoryBirthPlaceRepository(abbadiaCerretoUnderLodi());
+    $validator = new Validator($repository);
+
+    $valid = (new Generator())->generate(new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('2000-01-01'),
+        birthPlace: BirthPlaceCode::from('A004'),
+        gender: Gender::Male,
+    ));
+
+    expect($validator->validate($valid->value())->valid())->toBeTrue();
+});
+
+test('validate() reports only format errors for malformed input - checksum/semantics are never attempted', function () {
+    $validator = new Validator(new InMemoryBirthPlaceRepository());
+
+    // Too short to safely slice for checksum/semantic checks; if either
+    // were attempted regardless, this would produce spurious errors
+    // (or a crash) instead of exactly one clean InvalidFormat.
+    $result = $validator->validate('ABC');
+
+    expect($result->valid())->toBeFalse()
+        ->and($result->errors())->toBe([ValidationError::InvalidFormat]);
+});
+
+test('validate() reports checksum and semantic errors together for a well-formed but doubly-wrong code', function () {
+    $validator = new Validator(new InMemoryBirthPlaceRepository());
+
+    // RSSMRA95E05F205A: well-formed, wrong checksum (real one is Z),
+    // and F205 (Milano) is unrecognized by the empty repository.
+    $result = $validator->validate('RSSMRA95E05F205A');
+
+    expect($result->valid())->toBeFalse()
+        ->and($result->errors())->toBe([ValidationError::InvalidChecksum, ValidationError::UnknownBirthPlace]);
+});
+
+test("validator's public API has no method accepting a Person", function () {
+    $methods = (new ReflectionClass(Validator::class))->getMethods(ReflectionMethod::IS_PUBLIC);
+
+    foreach ($methods as $method) {
+        foreach ($method->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            $typeName = $type instanceof ReflectionNamedType ? $type->getName() : null;
+
+            expect($typeName)->not->toBe(Person::class);
+        }
+    }
+});


### PR DESCRIPTION
Closes #82.

## Design correction from the ticket's literal signature
The issue types `validate(CodiceFiscale): ValidationResult`, but `CodiceFiscale` can only ever be constructed already structurally valid (via `from()`/`tryFrom()`) — so AC1 ("a malformed string produces only format errors") is impossible to exercise with that signature. `validate()`/`validateFormat()` take a raw `string` instead; `validateChecksum()`/`validateSemantics()` stay `CodiceFiscale`-typed since they need guaranteed structure. Independently verified during review (grepped for any bypass of `from()`/`tryFrom()` — none exist) rather than taken on faith.

## Summary
- `validate()` gates on format first, then runs checksum and semantics independently and merges both into one `ValidationResult`.
- `validateSemantics()` distinguishes `UnknownBirthPlace` (code never existed) from `BirthPlaceNotValidOnDate` (existed, just not on this date) via the repository's `existedEver()`/`find()` split from #78 — verified against the real Abbadia Cerreto fixture.
- `ValidationResult::ok()`/`withError()` named constructors (added during review) remove a duplicated ternary shape.

## Test plan
- [x] 143 Pest tests passing (715 assertions), covering all 5 acceptance criteria including a reflection-based check that no public method accepts a `Person`
- [x] PHPStan level max passes clean
- [x] `php-cs-fixer --dry-run` passes
- [x] Reviewed via `/code-review` (Standards + Spec axes) — no hard violations; the Spec reviewer independently confirmed the type-signature deviation is justified rather than accepting the commit message's claim; two minor fixes applied (docblock explaining the signature split, `ValidationResult` named constructors)