### PR TITLE
Matcher

### DIFF
--- a/src/Data/PartialPerson.php
+++ b/src/Data/PartialPerson.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Data;
+
+use Robertogallea\CodiceFiscale\Enums\Gender;
+
+final readonly class PartialPerson
+{
+    public function __construct(
+        public ?string $firstName = null,
+        public ?string $lastName = null,
+        public ?\DateTimeImmutable $birthDate = null,
+        public ?BirthPlaceCode $birthPlace = null,
+        public ?Gender $gender = null,
+    ) {
+    }
+}

--- a/src/Enums/PersonField.php
+++ b/src/Enums/PersonField.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Enums;
+
+enum PersonField
+{
+    case FirstName;
+    case LastName;
+    case BirthDate;
+    case BirthPlace;
+    case Gender;
+}

--- a/src/Matching/MatchResult.php
+++ b/src/Matching/MatchResult.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Matching;
+
+use Robertogallea\CodiceFiscale\Enums\PersonField;
+
+final readonly class MatchResult
+{
+    /**
+     * @param  list<PersonField>  $matched
+     * @param  list<PersonField>  $mismatched
+     * @param  list<PersonField>  $skipped
+     */
+    public function __construct(
+        private array $matched,
+        private array $mismatched,
+        private array $skipped,
+    ) {
+    }
+
+    /**
+     * True when nothing checked failed - a fully verified match if
+     * skipped() is also empty, or a partial match (nothing checked
+     * failed, but some fields weren't provided) otherwise. False
+     * means an explicit mismatch.
+     */
+    public function matches(): bool
+    {
+        return $this->mismatched === [];
+    }
+
+    /** @return list<PersonField> */
+    public function matched(): array
+    {
+        return $this->matched;
+    }
+
+    /** @return list<PersonField> */
+    public function mismatched(): array
+    {
+        return $this->mismatched;
+    }
+
+    /** @return list<PersonField> */
+    public function skipped(): array
+    {
+        return $this->skipped;
+    }
+}

--- a/src/Matching/Matcher.php
+++ b/src/Matching/Matcher.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Matching;
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Contracts\NameNormalizer;
+use Robertogallea\CodiceFiscale\Data\PartialPerson;
+use Robertogallea\CodiceFiscale\Data\Person;
+use Robertogallea\CodiceFiscale\Enums\PersonField;
+use Robertogallea\CodiceFiscale\Generation\ItalianNameNormalizer;
+use Robertogallea\CodiceFiscale\Generation\NameEncoder;
+use Robertogallea\CodiceFiscale\Parsing\Parser;
+
+final class Matcher
+{
+    public function __construct(
+        private readonly Parser $parser,
+        private readonly NameNormalizer $nameNormalizer = new ItalianNameNormalizer(),
+        private readonly NameEncoder $nameEncoder = new NameEncoder(),
+    ) {
+    }
+
+    public function match(CodiceFiscale $cf, Person|PartialPerson $person): MatchResult
+    {
+        $parsed = $this->parser->parse($cf);
+
+        $matched = [];
+        $mismatched = [];
+        $skipped = [];
+
+        if ($person->lastName === null) {
+            $skipped[] = PersonField::LastName;
+        } else {
+            $expected = $this->nameEncoder->surnameCode($this->nameNormalizer->normalize($person->lastName));
+            $this->record($expected === $parsed->surnameCode(), PersonField::LastName, $matched, $mismatched);
+        }
+
+        if ($person->firstName === null) {
+            $skipped[] = PersonField::FirstName;
+        } else {
+            $expected = $this->nameEncoder->nameCode($this->nameNormalizer->normalize($person->firstName));
+            $this->record($expected === $parsed->nameCode(), PersonField::FirstName, $matched, $mismatched);
+        }
+
+        if ($person->birthDate === null) {
+            $skipped[] = PersonField::BirthDate;
+        } else {
+            $parsedDate = $parsed->birthDate();
+            $isMatch = $parsedDate !== null && $parsedDate->format('Y-m-d') === $person->birthDate->format('Y-m-d');
+            $this->record($isMatch, PersonField::BirthDate, $matched, $mismatched);
+        }
+
+        if ($person->birthPlace === null) {
+            $skipped[] = PersonField::BirthPlace;
+        } else {
+            $this->record($person->birthPlace->equals($parsed->birthPlaceCode()), PersonField::BirthPlace, $matched, $mismatched);
+        }
+
+        if ($person->gender === null) {
+            $skipped[] = PersonField::Gender;
+        } else {
+            $this->record($person->gender === $parsed->gender(), PersonField::Gender, $matched, $mismatched);
+        }
+
+        return new MatchResult($matched, $mismatched, $skipped);
+    }
+
+    /**
+     * @param  list<PersonField>  $matched
+     * @param  list<PersonField>  $mismatched
+     */
+    private function record(bool $isMatch, PersonField $field, array &$matched, array &$mismatched): void
+    {
+        if ($isMatch) {
+            $matched[] = $field;
+        } else {
+            $mismatched[] = $field;
+        }
+    }
+}

--- a/src/Matching/Matcher.php
+++ b/src/Matching/Matcher.php
@@ -30,51 +30,44 @@ final class Matcher
 
         if ($person->lastName === null) {
             $skipped[] = PersonField::LastName;
+        } elseif ($this->nameEncoder->surnameCode($this->nameNormalizer->normalize($person->lastName)) === $parsed->surnameCode()) {
+            $matched[] = PersonField::LastName;
         } else {
-            $expected = $this->nameEncoder->surnameCode($this->nameNormalizer->normalize($person->lastName));
-            $this->record($expected === $parsed->surnameCode(), PersonField::LastName, $matched, $mismatched);
+            $mismatched[] = PersonField::LastName;
         }
 
         if ($person->firstName === null) {
             $skipped[] = PersonField::FirstName;
+        } elseif ($this->nameEncoder->nameCode($this->nameNormalizer->normalize($person->firstName)) === $parsed->nameCode()) {
+            $matched[] = PersonField::FirstName;
         } else {
-            $expected = $this->nameEncoder->nameCode($this->nameNormalizer->normalize($person->firstName));
-            $this->record($expected === $parsed->nameCode(), PersonField::FirstName, $matched, $mismatched);
+            $mismatched[] = PersonField::FirstName;
         }
 
         if ($person->birthDate === null) {
             $skipped[] = PersonField::BirthDate;
+        } elseif ($parsed->birthDate()?->format('Y-m-d') === $person->birthDate->format('Y-m-d')) {
+            $matched[] = PersonField::BirthDate;
         } else {
-            $parsedDate = $parsed->birthDate();
-            $isMatch = $parsedDate !== null && $parsedDate->format('Y-m-d') === $person->birthDate->format('Y-m-d');
-            $this->record($isMatch, PersonField::BirthDate, $matched, $mismatched);
+            $mismatched[] = PersonField::BirthDate;
         }
 
         if ($person->birthPlace === null) {
             $skipped[] = PersonField::BirthPlace;
+        } elseif ($person->birthPlace->equals($parsed->birthPlaceCode())) {
+            $matched[] = PersonField::BirthPlace;
         } else {
-            $this->record($person->birthPlace->equals($parsed->birthPlaceCode()), PersonField::BirthPlace, $matched, $mismatched);
+            $mismatched[] = PersonField::BirthPlace;
         }
 
         if ($person->gender === null) {
             $skipped[] = PersonField::Gender;
+        } elseif ($person->gender === $parsed->gender()) {
+            $matched[] = PersonField::Gender;
         } else {
-            $this->record($person->gender === $parsed->gender(), PersonField::Gender, $matched, $mismatched);
+            $mismatched[] = PersonField::Gender;
         }
 
         return new MatchResult($matched, $mismatched, $skipped);
-    }
-
-    /**
-     * @param  list<PersonField>  $matched
-     * @param  list<PersonField>  $mismatched
-     */
-    private function record(bool $isMatch, PersonField $field, array &$matched, array &$mismatched): void
-    {
-        if ($isMatch) {
-            $matched[] = $field;
-        } else {
-            $mismatched[] = $field;
-        }
     }
 }

--- a/tests/Unit/MatcherTest.php
+++ b/tests/Unit/MatcherTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\PartialPerson;
+use Robertogallea\CodiceFiscale\Data\Person;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Enums\PersonField;
+use Robertogallea\CodiceFiscale\Generation\Generator;
+use Robertogallea\CodiceFiscale\Matching\Matcher;
+use Robertogallea\CodiceFiscale\Parsing\Parser;
+use Tests\Support\InMemoryBirthPlaceRepository;
+
+test('matching against the exact Person a code was generated from reports every field matched', function () {
+    $person = new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1995-05-05'),
+        birthPlace: BirthPlaceCode::from('F205'),
+        gender: Gender::Male,
+    );
+    $cf = (new Generator())->generate($person);
+
+    $matcher = new Matcher(new Parser(new InMemoryBirthPlaceRepository()));
+    $result = $matcher->match($cf, $person);
+
+    expect($result->matches())->toBeTrue()
+        ->and($result->matched())->toEqualCanonicalizing([
+            PersonField::FirstName,
+            PersonField::LastName,
+            PersonField::BirthDate,
+            PersonField::BirthPlace,
+            PersonField::Gender,
+        ])
+        ->and($result->mismatched())->toBe([])
+        ->and($result->skipped())->toBe([]);
+});
+
+test('matching against a PartialPerson with only firstName/lastName set reports the rest as skipped, not matched', function () {
+    $cf = (new Generator())->generate(new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1995-05-05'),
+        birthPlace: BirthPlaceCode::from('F205'),
+        gender: Gender::Male,
+    ));
+
+    $partial = new PartialPerson(firstName: 'Mario', lastName: 'Rossi');
+
+    $matcher = new Matcher(new Parser(new InMemoryBirthPlaceRepository()));
+    $result = $matcher->match($cf, $partial);
+
+    expect($result->matches())->toBeTrue()
+        ->and($result->matched())->toEqualCanonicalizing([PersonField::FirstName, PersonField::LastName])
+        ->and($result->mismatched())->toBe([])
+        ->and($result->skipped())->toEqualCanonicalizing([
+            PersonField::BirthDate,
+            PersonField::BirthPlace,
+            PersonField::Gender,
+        ]);
+});
+
+test('the three states are distinguishable: fully verified vs. partial-nothing-failed vs. explicit mismatch', function () {
+    $cf = (new Generator())->generate(new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1995-05-05'),
+        birthPlace: BirthPlaceCode::from('F205'),
+        gender: Gender::Male,
+    ));
+    $matcher = new Matcher(new Parser(new InMemoryBirthPlaceRepository()));
+
+    $fullyVerified = $matcher->match($cf, new Person(
+        firstName: 'Mario', lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1995-05-05'),
+        birthPlace: BirthPlaceCode::from('F205'), gender: Gender::Male,
+    ));
+    expect($fullyVerified->matches())->toBeTrue()->and($fullyVerified->skipped())->toBe([]);
+
+    $partialNothingFailed = $matcher->match($cf, new PartialPerson(firstName: 'Mario'));
+    expect($partialNothingFailed->matches())->toBeTrue()->and($partialNothingFailed->skipped())->not->toBe([]);
+
+    $explicitMismatch = $matcher->match($cf, new PartialPerson(firstName: 'Luigi'));
+    expect($explicitMismatch->matches())->toBeFalse();
+});
+
+test('changing a single field before matching reports exactly that field as mismatched, the rest matched', function () {
+    $generatedFrom = new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1995-05-05'),
+        birthPlace: BirthPlaceCode::from('F205'),
+        gender: Gender::Male,
+    );
+    $cf = (new Generator())->generate($generatedFrom);
+
+    $withDifferentGender = new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1995-05-05'),
+        birthPlace: BirthPlaceCode::from('F205'),
+        gender: Gender::Female,
+    );
+
+    $matcher = new Matcher(new Parser(new InMemoryBirthPlaceRepository()));
+    $result = $matcher->match($cf, $withDifferentGender);
+
+    expect($result->matches())->toBeFalse()
+        ->and($result->mismatched())->toBe([PersonField::Gender])
+        ->and($result->matched())->toEqualCanonicalizing([
+            PersonField::FirstName,
+            PersonField::LastName,
+            PersonField::BirthDate,
+            PersonField::BirthPlace,
+        ])
+        ->and($result->skipped())->toBe([]);
+});

--- a/tests/Unit/MatcherTest.php
+++ b/tests/Unit/MatcherTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Robertogallea\CodiceFiscale\CodiceFiscale;
 use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
 use Robertogallea\CodiceFiscale\Data\PartialPerson;
 use Robertogallea\CodiceFiscale\Data\Person;
@@ -113,4 +114,17 @@ test('changing a single field before matching reports exactly that field as mism
             PersonField::BirthPlace,
         ])
         ->and($result->skipped())->toBe([]);
+});
+
+test('birthDate mismatches (not skips or crashes) when the code encodes an undecodable date', function () {
+    // Day 77 -> female (>40), day 37: not a real day of any month, so
+    // ParsedCodiceFiscale::birthDate() is null. A caller-provided
+    // birthDate can never be a real match against "no date at all".
+    $cf = CodiceFiscale::from('LOIMLC71A77F979V');
+
+    $matcher = new Matcher(new Parser(new InMemoryBirthPlaceRepository()));
+    $result = $matcher->match($cf, new PartialPerson(birthDate: new DateTimeImmutable('1971-01-01')));
+
+    expect($result->matches())->toBeFalse()
+        ->and($result->mismatched())->toBe([PersonField::BirthDate]);
 });


### PR DESCRIPTION
Closes #83.

## Summary
- `Matcher::match(CodiceFiscale, Person|PartialPerson): MatchResult` — re-derives expected surname/name codes via the same `NameNormalizer`+`NameEncoder` `Generator` uses, then compares each of the 5 fields independently against `Parser`'s decoded output.
- `MatchResult` exposes `matched()`/`mismatched()`/`skipped()` as three explicit buckets (keyed by a new `PersonField` enum), plus a `matches()` convenience. The three AC4 states (fully verified / partial-nothing-failed / explicit mismatch) are derivable from `matches()` + `skipped()` alone.
- `PartialPerson` (all-nullable sibling of `Person`) — new, required by the issue's own `Person|PartialPerson` signature but not built by any earlier ticket.
- `birthDate` mismatches (never skips or crashes) when the code encodes an undecodable date, since there's no way a real date could match "no date at all."

## Test plan
- [x] 148 Pest tests passing (734 assertions), covering all 4 acceptance criteria
- [x] PHPStan level max passes clean
- [x] `php-cs-fixer --dry-run` passes
- [x] Reviewed via `/code-review` (Standards + Spec axes) — no hard violations; confirmed the name-encoding collision risk (two different names encoding to the same 3-letter code) is an inherent, symmetric property of the codice fiscale format itself, not a defect; two fixes applied (inlined an awkward by-reference helper, added the one real test gap the review found — the null-parsed-birthDate mismatch case)