### PR TITLE
Eloquent birthplace repository

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -160,6 +160,8 @@ $finder = Finder::create()
     ->in([
         __DIR__.'/src',
         __DIR__.'/tests',
+        __DIR__.'/config',
+        __DIR__.'/database',
     ])
     ->name('*.php')
     ->notName('*.blade.php')

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
         }
     ],
     "require": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "illuminate/database": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.0",
@@ -35,6 +37,13 @@
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Robertogallea\\CodiceFiscale\\Laravel\\CodiceFiscaleServiceProvider"
+            ]
         }
     }
 }

--- a/config/codicefiscale.php
+++ b/config/codicefiscale.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'database' => [
+        // Path to the dedicated SQLite file backing the birthplace
+        // repository. Never the host application's own database -
+        // installing/using this package doesn't touch it. Set this
+        // to ':memory:' (e.g. in tests) for an ephemeral database.
+        'path' => storage_path('app/codicefiscale/places.sqlite'),
+    ],
+];

--- a/database/migrations/2024_01_01_000001_create_municipalities_table.php
+++ b/database/migrations/2024_01_01_000001_create_municipalities_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    protected $connection = 'codicefiscale';
+
+    public function up(): void
+    {
+        Schema::create('municipalities', function (Blueprint $table) {
+            $table->id();
+            $table->string('code', 4)->index();
+            $table->string('name');
+            $table->string('province', 2);
+            $table->string('istat_code', 6);
+            $table->date('valid_from');
+            $table->date('valid_to')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('municipalities');
+    }
+};

--- a/database/migrations/2024_01_01_000002_create_foreign_countries_table.php
+++ b/database/migrations/2024_01_01_000002_create_foreign_countries_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    protected $connection = 'codicefiscale';
+
+    public function up(): void
+    {
+        Schema::create('foreign_countries', function (Blueprint $table) {
+            $table->id();
+            $table->string('code', 4)->index();
+            $table->string('name');
+            $table->string('country_code', 3);
+            $table->date('valid_from');
+            $table->date('valid_to')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('foreign_countries');
+    }
+};

--- a/src/Laravel/BirthPlaces/CompositeBirthPlaceRepository.php
+++ b/src/Laravel/BirthPlaces/CompositeBirthPlaceRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Laravel\BirthPlaces;
+
+use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+
+/**
+ * Routes a domestic code to the Municipality-backed repository and a
+ * foreign (Z-prefixed) code to the ForeignCountry-backed one.
+ */
+final class CompositeBirthPlaceRepository implements BirthPlaceRepository
+{
+    public function __construct(
+        private readonly BirthPlaceRepository $domestic,
+        private readonly BirthPlaceRepository $foreign,
+    ) {
+    }
+
+    public function find(BirthPlaceCode $code, ?\DateTimeImmutable $on = null): ?BirthPlace
+    {
+        return $this->repositoryFor($code)->find($code, $on);
+    }
+
+    public function existedEver(BirthPlaceCode $code): bool
+    {
+        return $this->repositoryFor($code)->existedEver($code);
+    }
+
+    private function repositoryFor(BirthPlaceCode $code): BirthPlaceRepository
+    {
+        return $code->isForeign() ? $this->foreign : $this->domestic;
+    }
+}

--- a/src/Laravel/BirthPlaces/ConvertsToBirthPlace.php
+++ b/src/Laravel/BirthPlaces/ConvertsToBirthPlace.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Laravel\BirthPlaces;
+
+use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
+
+/**
+ * Implemented by each Eloquent model backing a BirthPlaceRepository,
+ * so EloquentBirthPlaceRepository can map a row to its domain object
+ * without needing to know which concrete model it's querying.
+ */
+interface ConvertsToBirthPlace
+{
+    public function toBirthPlace(): BirthPlace;
+}

--- a/src/Laravel/BirthPlaces/EloquentBirthPlaceRepository.php
+++ b/src/Laravel/BirthPlaces/EloquentBirthPlaceRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Laravel\BirthPlaces;
+
+use Illuminate\Database\Eloquent\Model;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+
+/**
+ * Generic BirthPlaceRepository backed by a single Eloquent model -
+ * works for either Municipality or ForeignCountry, since both share
+ * the same code/valid_from/valid_to shape and each knows how to turn
+ * its own row into the right BirthPlace via ConvertsToBirthPlace.
+ */
+final class EloquentBirthPlaceRepository implements BirthPlaceRepository
+{
+    /** @param class-string<Model&ConvertsToBirthPlace> $modelClass */
+    public function __construct(
+        private readonly string $modelClass,
+    ) {
+    }
+
+    public function find(BirthPlaceCode $code, ?\DateTimeImmutable $on = null): ?BirthPlace
+    {
+        $on ??= new \DateTimeImmutable('today');
+        $onDate = $on->format('Y-m-d');
+
+        /** @var (Model&ConvertsToBirthPlace)|null $row */
+        $row = $this->modelClass::query()
+            ->where('code', $code->value())
+            ->where('valid_from', '<=', $onDate)
+            ->where(function ($query) use ($onDate) {
+                $query->whereNull('valid_to')->orWhere('valid_to', '>', $onDate);
+            })
+            ->first();
+
+        return $row?->toBirthPlace();
+    }
+
+    public function existedEver(BirthPlaceCode $code): bool
+    {
+        return $this->modelClass::query()->where('code', $code->value())->exists();
+    }
+}

--- a/src/Laravel/BirthPlaces/EloquentBirthPlaceRepository.php
+++ b/src/Laravel/BirthPlaces/EloquentBirthPlaceRepository.php
@@ -2,10 +2,11 @@
 
 namespace Robertogallea\CodiceFiscale\Laravel\BirthPlaces;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
 use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
 use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\AbstractBirthPlaceModel;
 
 /**
  * Generic BirthPlaceRepository backed by a single Eloquent model -
@@ -15,7 +16,7 @@ use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
  */
 final class EloquentBirthPlaceRepository implements BirthPlaceRepository
 {
-    /** @param class-string<Model&ConvertsToBirthPlace> $modelClass */
+    /** @param class-string<AbstractBirthPlaceModel> $modelClass */
     public function __construct(
         private readonly string $modelClass,
     ) {
@@ -24,14 +25,18 @@ final class EloquentBirthPlaceRepository implements BirthPlaceRepository
     public function find(BirthPlaceCode $code, ?\DateTimeImmutable $on = null): ?BirthPlace
     {
         $on ??= new \DateTimeImmutable('today');
-        $onDate = $on->format('Y-m-d');
 
-        /** @var (Model&ConvertsToBirthPlace)|null $row */
+        // PHPStan can't follow the generic self-type through a dynamic
+        // class-string::query() call without Larastan; $modelClass is
+        // already constrained to class-string<AbstractBirthPlaceModel>
+        // by the constructor's @param, so this is narrowing a type
+        // PHPStan can't derive on its own, not overriding a correct one.
+        /** @var AbstractBirthPlaceModel|null $row */
         $row = $this->modelClass::query()
             ->where('code', $code->value())
-            ->where('valid_from', '<=', $onDate)
-            ->where(function ($query) use ($onDate) {
-                $query->whereNull('valid_to')->orWhere('valid_to', '>', $onDate);
+            ->whereDate('valid_from', '<=', $on)
+            ->where(function (Builder $query) use ($on) {
+                $query->whereNull('valid_to')->orWhereDate('valid_to', '>', $on);
             })
             ->first();
 

--- a/src/Laravel/BirthPlaces/Models/AbstractBirthPlaceModel.php
+++ b/src/Laravel/BirthPlaces/Models/AbstractBirthPlaceModel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\ConvertsToBirthPlace;
+
+/**
+ * Shared connection/timestamps/casts boilerplate for Municipality and
+ * ForeignCountry - the concept of a "row valid on a [validFrom,
+ * validTo) window" is common to both, even though their own data
+ * columns (province/istat_code vs country_code) are not.
+ */
+abstract class AbstractBirthPlaceModel extends Model implements ConvertsToBirthPlace
+{
+    protected $connection = 'codicefiscale';
+
+    public $timestamps = false;
+
+    protected function casts(): array
+    {
+        return [
+            'valid_from' => 'immutable_date',
+            'valid_to' => 'immutable_date',
+        ];
+    }
+}

--- a/src/Laravel/BirthPlaces/Models/ForeignCountry.php
+++ b/src/Laravel/BirthPlaces/Models/ForeignCountry.php
@@ -2,12 +2,10 @@
 
 namespace Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
 use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
 use Robertogallea\CodiceFiscale\Data\CountryCode;
 use Robertogallea\CodiceFiscale\Data\ForeignBirthPlace;
-use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\ConvertsToBirthPlace;
 
 /**
  * @property string $code
@@ -16,23 +14,11 @@ use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\ConvertsToBirthPlace;
  * @property \Carbon\CarbonImmutable $valid_from
  * @property \Carbon\CarbonImmutable|null $valid_to
  */
-final class ForeignCountry extends Model implements ConvertsToBirthPlace
+final class ForeignCountry extends AbstractBirthPlaceModel
 {
-    protected $connection = 'codicefiscale';
-
-    public $timestamps = false;
-
     protected $table = 'foreign_countries';
 
     protected $fillable = ['code', 'name', 'country_code', 'valid_from', 'valid_to'];
-
-    protected function casts(): array
-    {
-        return [
-            'valid_from' => 'immutable_date',
-            'valid_to' => 'immutable_date',
-        ];
-    }
 
     public function toBirthPlace(): BirthPlace
     {

--- a/src/Laravel/BirthPlaces/Models/ForeignCountry.php
+++ b/src/Laravel/BirthPlaces/Models/ForeignCountry.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\CountryCode;
+use Robertogallea\CodiceFiscale\Data\ForeignBirthPlace;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\ConvertsToBirthPlace;
+
+/**
+ * @property string $code
+ * @property string $name
+ * @property string $country_code
+ * @property \Carbon\CarbonImmutable $valid_from
+ * @property \Carbon\CarbonImmutable|null $valid_to
+ */
+final class ForeignCountry extends Model implements ConvertsToBirthPlace
+{
+    protected $connection = 'codicefiscale';
+
+    public $timestamps = false;
+
+    protected $table = 'foreign_countries';
+
+    protected $fillable = ['code', 'name', 'country_code', 'valid_from', 'valid_to'];
+
+    protected function casts(): array
+    {
+        return [
+            'valid_from' => 'immutable_date',
+            'valid_to' => 'immutable_date',
+        ];
+    }
+
+    public function toBirthPlace(): BirthPlace
+    {
+        return new ForeignBirthPlace(
+            code: BirthPlaceCode::from($this->code),
+            name: $this->name,
+            country: CountryCode::from($this->country_code),
+            validFrom: $this->valid_from,
+            validTo: $this->valid_to,
+        );
+    }
+}

--- a/src/Laravel/BirthPlaces/Models/Municipality.php
+++ b/src/Laravel/BirthPlaces/Models/Municipality.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\DomesticBirthPlace;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\ConvertsToBirthPlace;
+
+/**
+ * @property string $code
+ * @property string $name
+ * @property string $province
+ * @property string $istat_code
+ * @property \Carbon\CarbonImmutable $valid_from
+ * @property \Carbon\CarbonImmutable|null $valid_to
+ */
+final class Municipality extends Model implements ConvertsToBirthPlace
+{
+    protected $connection = 'codicefiscale';
+
+    public $timestamps = false;
+
+    protected $fillable = ['code', 'name', 'province', 'istat_code', 'valid_from', 'valid_to'];
+
+    protected function casts(): array
+    {
+        return [
+            'valid_from' => 'immutable_date',
+            'valid_to' => 'immutable_date',
+        ];
+    }
+
+    public function toBirthPlace(): BirthPlace
+    {
+        return new DomesticBirthPlace(
+            code: BirthPlaceCode::from($this->code),
+            name: $this->name,
+            province: $this->province,
+            istatCode: $this->istat_code,
+            validFrom: $this->valid_from,
+            validTo: $this->valid_to,
+        );
+    }
+}

--- a/src/Laravel/BirthPlaces/Models/Municipality.php
+++ b/src/Laravel/BirthPlaces/Models/Municipality.php
@@ -2,11 +2,9 @@
 
 namespace Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Robertogallea\CodiceFiscale\Contracts\BirthPlace;
 use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
 use Robertogallea\CodiceFiscale\Data\DomesticBirthPlace;
-use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\ConvertsToBirthPlace;
 
 /**
  * @property string $code
@@ -16,21 +14,9 @@ use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\ConvertsToBirthPlace;
  * @property \Carbon\CarbonImmutable $valid_from
  * @property \Carbon\CarbonImmutable|null $valid_to
  */
-final class Municipality extends Model implements ConvertsToBirthPlace
+final class Municipality extends AbstractBirthPlaceModel
 {
-    protected $connection = 'codicefiscale';
-
-    public $timestamps = false;
-
     protected $fillable = ['code', 'name', 'province', 'istat_code', 'valid_from', 'valid_to'];
-
-    protected function casts(): array
-    {
-        return [
-            'valid_from' => 'immutable_date',
-            'valid_to' => 'immutable_date',
-        ];
-    }
 
     public function toBirthPlace(): BirthPlace
     {

--- a/src/Laravel/CodiceFiscaleServiceProvider.php
+++ b/src/Laravel/CodiceFiscaleServiceProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Laravel;
+
+use Illuminate\Support\ServiceProvider;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\CompositeBirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\EloquentBirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\ForeignCountry;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\Municipality;
+
+class CodiceFiscaleServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom($this->packagePath('config/codicefiscale.php'), 'codicefiscale');
+
+        $this->app->bind(BirthPlaceRepository::class, function () {
+            return new CompositeBirthPlaceRepository(
+                new EloquentBirthPlaceRepository(Municipality::class),
+                new EloquentBirthPlaceRepository(ForeignCountry::class),
+            );
+        });
+    }
+
+    public function boot(): void
+    {
+        // Deliberately not in register(): the database connection
+        // must reflect final config state (host app config, published
+        // config overrides, or a test's environment overrides), and
+        // register() runs too early for that - before those overrides
+        // are applied. Container bindings above stay in register()
+        // since they're resolved lazily, well after boot() completes.
+        $this->registerDatabaseConnection();
+
+        $this->loadMigrationsFrom($this->packagePath('database/migrations'));
+
+        $this->publishes([
+            $this->packagePath('config/codicefiscale.php') => config_path('codicefiscale.php'),
+        ], 'config');
+    }
+
+    private function registerDatabaseConnection(): void
+    {
+        /** @var string $path */
+        $path = config('codicefiscale.database.path');
+
+        if ($path !== ':memory:' && ! file_exists($path)) {
+            @mkdir(dirname($path), 0755, true);
+            touch($path);
+        }
+
+        config([
+            'database.connections.codicefiscale' => [
+                'driver' => 'sqlite',
+                'database' => $path,
+                'prefix' => '',
+                'foreign_key_constraints' => true,
+            ],
+        ]);
+    }
+
+    private function packagePath(string $path): string
+    {
+        return __DIR__."/../../$path";
+    }
+}

--- a/src/Laravel/CodiceFiscaleServiceProvider.php
+++ b/src/Laravel/CodiceFiscaleServiceProvider.php
@@ -2,6 +2,11 @@
 
 namespace Robertogallea\CodiceFiscale\Laravel;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Migrations\DatabaseMigrationRepository;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
 use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
 use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\CompositeBirthPlaceRepository;
@@ -32,8 +37,7 @@ class CodiceFiscaleServiceProvider extends ServiceProvider
         // are applied. Container bindings above stay in register()
         // since they're resolved lazily, well after boot() completes.
         $this->registerDatabaseConnection();
-
-        $this->loadMigrationsFrom($this->packagePath('database/migrations'));
+        $this->migrate();
 
         $this->publishes([
             $this->packagePath('config/codicefiscale.php') => config_path('codicefiscale.php'),
@@ -46,8 +50,13 @@ class CodiceFiscaleServiceProvider extends ServiceProvider
         $path = config('codicefiscale.database.path');
 
         if ($path !== ':memory:' && ! file_exists($path)) {
-            @mkdir(dirname($path), 0755, true);
-            touch($path);
+            if (! is_dir(dirname($path)) && ! mkdir(dirname($path), 0755, true) && ! is_dir(dirname($path))) {
+                throw new \RuntimeException("Unable to create directory for the codicefiscale SQLite database at \"$path\".");
+            }
+
+            if (touch($path) === false) {
+                throw new \RuntimeException("Unable to create the codicefiscale SQLite database file at \"$path\".");
+            }
         }
 
         config([
@@ -58,6 +67,52 @@ class CodiceFiscaleServiceProvider extends ServiceProvider
                 'foreign_key_constraints' => true,
             ],
         ]);
+    }
+
+    /**
+     * Deliberately NOT loadMigrationsFrom(): that registers migrations
+     * into the host application's own shared "migrate" command, whose
+     * bookkeeping repository connection is governed by that command's
+     * --database option (or config('database.default') if omitted) -
+     * NOT by each migration's own $connection property. A bare
+     * `php artisan migrate` in a host app would write tracking rows
+     * for our migrations into the *host's own default connection's*
+     * migrations table, even though the schema itself correctly lands
+     * on ours. Running our own isolated Migrator/repository instance
+     * here never touches the host's migration command or its
+     * repository singleton at all.
+     *
+     * Migrator::setConnection() has its own surprising side effect:
+     * it also calls the connection resolver's setDefaultConnection(),
+     * globally changing config('database.default') for the rest of
+     * the request/process. Saving and restoring it around the run
+     * keeps that mutation from ever escaping this method.
+     */
+    private function migrate(): void
+    {
+        $db = $this->app->make(DatabaseManager::class);
+        $originalDefaultConnection = $db->getDefaultConnection();
+
+        $repository = new DatabaseMigrationRepository($db, 'migrations');
+        $repository->setSource('codicefiscale');
+
+        if (! $repository->repositoryExists()) {
+            $repository->createRepository();
+        }
+
+        $migrator = new Migrator(
+            $repository,
+            $db,
+            $this->app->make(Filesystem::class),
+            $this->app->make(Dispatcher::class),
+        );
+
+        try {
+            $migrator->setConnection('codicefiscale');
+            $migrator->run([$this->packagePath('database/migrations')]);
+        } finally {
+            $db->setDefaultConnection($originalDefaultConnection);
+        }
     }
 
     private function packagePath(string $path): string

--- a/tests/Feature/CompositeBirthPlaceRepositoryTest.php
+++ b/tests/Feature/CompositeBirthPlaceRepositoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\DomesticBirthPlace;
+use Robertogallea\CodiceFiscale\Data\ForeignBirthPlace;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\CompositeBirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\EloquentBirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\ForeignCountry;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\Municipality;
+
+function compositeBirthPlaceRepository(): CompositeBirthPlaceRepository
+{
+    return new CompositeBirthPlaceRepository(
+        new EloquentBirthPlaceRepository(Municipality::class),
+        new EloquentBirthPlaceRepository(ForeignCountry::class),
+    );
+}
+
+test('routes a domestic code to Municipality', function () {
+    Municipality::create([
+        'code' => 'H501', 'name' => 'ROMA', 'province' => 'RM',
+        'istat_code' => '058091', 'valid_from' => '1871-01-01', 'valid_to' => null,
+    ]);
+    // A same-shaped row in the wrong table must never be picked up.
+    ForeignCountry::create([
+        'code' => 'H501', 'name' => 'WRONG TABLE', 'country_code' => 'XXX',
+        'valid_from' => '1900-01-01', 'valid_to' => null,
+    ]);
+
+    $place = compositeBirthPlaceRepository()->find(BirthPlaceCode::from('H501'));
+
+    expect($place)->toBeInstanceOf(DomesticBirthPlace::class)
+        ->and($place->name())->toBe('ROMA');
+});
+
+test('routes a foreign (Z-prefixed) code to ForeignCountry', function () {
+    ForeignCountry::create([
+        'code' => 'Z404', 'name' => "STATI UNITI D'AMERICA", 'country_code' => 'USA',
+        'valid_from' => '1900-01-01', 'valid_to' => null,
+    ]);
+
+    $place = compositeBirthPlaceRepository()->find(BirthPlaceCode::from('Z404'));
+
+    expect($place)->toBeInstanceOf(ForeignBirthPlace::class)
+        ->and($place->country()->value())->toBe('USA');
+});
+
+test('existedEver() also routes by code kind', function () {
+    Municipality::create([
+        'code' => 'H501', 'name' => 'ROMA', 'province' => 'RM',
+        'istat_code' => '058091', 'valid_from' => '1871-01-01', 'valid_to' => null,
+    ]);
+
+    $composite = compositeBirthPlaceRepository();
+
+    expect($composite->existedEver(BirthPlaceCode::from('H501')))->toBeTrue()
+        ->and($composite->existedEver(BirthPlaceCode::from('Z404')))->toBeFalse();
+});

--- a/tests/Feature/ConnectionIsolationTest.php
+++ b/tests/Feature/ConnectionIsolationTest.php
@@ -36,3 +36,23 @@ test("installing this package never touches the host application's own connectio
         expect($leakedIntoDefault)->toBe(0);
     }
 });
+
+test('a bare "php artisan migrate" - exactly what a real host app runs for its own migrations - never touches our tables or bookkeeping', function () {
+    $defaultConnection = config('database.default');
+
+    // No --database flag: this is precisely the host's own ordinary
+    // workflow, run *in addition to* our provider's own automatic
+    // migration in boot(). Our migrations are deliberately never
+    // registered via loadMigrationsFrom(), so the host's shared
+    // migrate command has no way to know about - or touch - them.
+    $this->artisan('migrate')->run();
+
+    $leaked = Schema::connection($defaultConnection)->hasTable('migrations')
+        ? DB::connection($defaultConnection)->table('migrations')
+            ->where('migration', 'like', '%municipalities%')
+            ->orWhere('migration', 'like', '%foreign_countries%')
+            ->count()
+        : 0;
+
+    expect($leaked)->toBe(0);
+});

--- a/tests/Feature/ConnectionIsolationTest.php
+++ b/tests/Feature/ConnectionIsolationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+test('the dedicated connection is registered automatically, distinct from the host app default', function () {
+    expect(config('database.connections.codicefiscale'))->not->toBeNull()
+        ->and(config('database.connections.codicefiscale.driver'))->toBe('sqlite')
+        ->and(config('database.default'))->not->toBe('codicefiscale');
+});
+
+test("installing this package never touches the host application's own connection or its migrations", function () {
+    $defaultConnection = config('database.default');
+
+    // Our tables exist on our dedicated connection...
+    expect(Schema::connection('codicefiscale')->hasTable('municipalities'))->toBeTrue()
+        ->and(Schema::connection('codicefiscale')->hasTable('foreign_countries'))->toBeTrue();
+
+    // ...and nowhere near the host app's own default connection.
+    expect(Schema::connection($defaultConnection)->hasTable('municipalities'))->toBeFalse()
+        ->and(Schema::connection($defaultConnection)->hasTable('foreign_countries'))->toBeFalse();
+
+    // Our package's migrations are recorded against our own
+    // connection's migrations table, not the host's.
+    $ourMigrations = DB::connection('codicefiscale')->table('migrations')
+        ->where('migration', 'like', '%municipalities%')
+        ->orWhere('migration', 'like', '%foreign_countries%')
+        ->count();
+    expect($ourMigrations)->toBe(2);
+
+    if (Schema::connection($defaultConnection)->hasTable('migrations')) {
+        $leakedIntoDefault = DB::connection($defaultConnection)->table('migrations')
+            ->where('migration', 'like', '%municipalities%')
+            ->orWhere('migration', 'like', '%foreign_countries%')
+            ->count();
+        expect($leakedIntoDefault)->toBe(0);
+    }
+});

--- a/tests/Feature/EloquentBirthPlaceRepositoryTest.php
+++ b/tests/Feature/EloquentBirthPlaceRepositoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\EloquentBirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\ForeignCountry;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\Municipality;
+
+test('smoke: can insert a row and find it back through the repository', function () {
+    Municipality::create([
+        'code' => 'H501',
+        'name' => 'ROMA',
+        'province' => 'RM',
+        'istat_code' => '058091',
+        'valid_from' => '1871-01-01',
+        'valid_to' => null,
+    ]);
+
+    $repository = new EloquentBirthPlaceRepository(Municipality::class);
+    $place = $repository->find(BirthPlaceCode::from('H501'));
+
+    expect($place)->not->toBeNull()
+        ->and($place->name())->toBe('ROMA');
+});
+
+test('find() resolves the era-record valid on the given date - the real Abbadia Cerreto province change', function () {
+    Municipality::create([
+        'code' => 'A004', 'name' => 'ABBADIA CERRETO', 'province' => 'MI',
+        'istat_code' => '015001', 'valid_from' => '1861-03-17', 'valid_to' => '1992-04-16',
+    ]);
+    Municipality::create([
+        'code' => 'A004', 'name' => 'ABBADIA CERRETO', 'province' => 'LO',
+        'istat_code' => '098001', 'valid_from' => '1992-04-16', 'valid_to' => null,
+    ]);
+
+    $repository = new EloquentBirthPlaceRepository(Municipality::class);
+    $code = BirthPlaceCode::from('A004');
+
+    expect($repository->find($code, new DateTimeImmutable('1950-01-01'))->province())->toBe('MI')
+        ->and($repository->find($code, new DateTimeImmutable('2000-01-01'))->province())->toBe('LO');
+});
+
+test('find() defaults to today when no date is given', function () {
+    Municipality::create([
+        'code' => 'A004', 'name' => 'ABBADIA CERRETO', 'province' => 'LO',
+        'istat_code' => '098001', 'valid_from' => '1992-04-16', 'valid_to' => null,
+    ]);
+
+    $repository = new EloquentBirthPlaceRepository(Municipality::class);
+
+    expect($repository->find(BirthPlaceCode::from('A004'))->province())->toBe('LO');
+});
+
+test('find() returns null for a code that never existed', function () {
+    $repository = new EloquentBirthPlaceRepository(Municipality::class);
+
+    expect($repository->find(BirthPlaceCode::from('Z999')))->toBeNull();
+});
+
+test('find() returns null for a code that existed, but not on the given date', function () {
+    Municipality::create([
+        'code' => 'A004', 'name' => 'ABBADIA CERRETO', 'province' => 'MI',
+        'istat_code' => '015001', 'valid_from' => '1861-03-17', 'valid_to' => '1992-04-16',
+    ]);
+
+    $repository = new EloquentBirthPlaceRepository(Municipality::class);
+
+    expect($repository->find(BirthPlaceCode::from('A004'), new DateTimeImmutable('1800-01-01')))->toBeNull();
+});
+
+test('existedEver() distinguishes a never-known code from a known one', function () {
+    Municipality::create([
+        'code' => 'A004', 'name' => 'ABBADIA CERRETO', 'province' => 'MI',
+        'istat_code' => '015001', 'valid_from' => '1861-03-17', 'valid_to' => '1992-04-16',
+    ]);
+
+    $repository = new EloquentBirthPlaceRepository(Municipality::class);
+
+    expect($repository->existedEver(BirthPlaceCode::from('A004')))->toBeTrue()
+        ->and($repository->existedEver(BirthPlaceCode::from('Z999')))->toBeFalse();
+});
+
+test('resolves a foreign birthplace via the ForeignCountry model', function () {
+    ForeignCountry::create([
+        'code' => 'Z404', 'name' => "STATI UNITI D'AMERICA", 'country_code' => 'USA',
+        'valid_from' => '1900-01-01', 'valid_to' => null,
+    ]);
+
+    $repository = new EloquentBirthPlaceRepository(ForeignCountry::class);
+    $place = $repository->find(BirthPlaceCode::from('Z404'));
+
+    expect($place->country()->value())->toBe('USA');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,13 +16,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function defineEnvironment($app): void
     {
         // Ephemeral, per-test database - never a real file on disk.
+        // The service provider migrates it automatically in boot(),
+        // via its own isolated Migrator - no manual artisan call needed.
         $app['config']->set('codicefiscale.database.path', ':memory:');
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->artisan('migrate', ['--database' => 'codicefiscale'])->run();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,27 @@
 
 namespace Tests;
 
+use Robertogallea\CodiceFiscale\Laravel\CodiceFiscaleServiceProvider;
+
 class TestCase extends \Orchestra\Testbench\TestCase
 {
     protected function getPackageProviders($app): array
     {
-        return [];
+        return [
+            CodiceFiscaleServiceProvider::class,
+        ];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        // Ephemeral, per-test database - never a real file on disk.
+        $app['config']->set('codicefiscale.database.path', ':memory:');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('migrate', ['--database' => 'codicefiscale'])->run();
     }
 }


### PR DESCRIPTION
Closes #84.

First Laravel-layer ticket in the rewrite — everything before this was framework-agnostic Core code.

## Summary
- `CodiceFiscaleServiceProvider` registers a dedicated SQLite connection (`config/codicefiscale.php`, `:memory:` in tests) and binds `BirthPlaceRepository` to a `CompositeBirthPlaceRepository`.
- `EloquentBirthPlaceRepository` is generic over a single Eloquent model via a shared `ConvertsToBirthPlace` interface — one class works for both `Municipality` and `ForeignCountry`, each knowing how to turn its own row into the right `BirthPlace`.
- `CompositeBirthPlaceRepository` routes by `BirthPlaceCode::isForeign()`.

## Two real bugs found and fixed during review (both independently reproduced before fixing, not taken on faith)
1. **AC2 violation**: `loadMigrationsFrom()` structurally can't achieve true connection isolation — Laravel's migration bookkeeping repository is a single shared instance per `migrate` invocation, governed by `--database` (or `config('database.default')` if omitted), not by each migration's own `$connection` property. A bare `php artisan migrate` — exactly what a real host app runs — wrote 2 tracking rows into the *host's own* default connection's migrations table. Fixed by running our own isolated `Migrator`/`DatabaseMigrationRepository` instance in `boot()`, never touching the host's shared migration command at all.
2. **A side effect of that fix**: `Migrator::setConnection()` also globally mutates `config('database.default')` via the connection resolver. Caught by the test suite itself failing after the first fix attempt (not assumed away) — now saved and restored around the migration run.

## Test plan
- [x] 161 Pest tests passing (759 assertions), including a test that runs a bare `php artisan migrate` (the real host scenario) and confirms zero rows land in the host's own migrations table
- [x] PHPStan level max passes clean (no Larastan needed — plain PHPStan handled Eloquent models fine with `@property` docblocks)
- [x] `php-cs-fixer --dry-run` passes
- [x] Reviewed via `/code-review` (Standards + Spec axes) — one real, verified AC2 bug and its own fix's side effect, both fixed; two minor dedup fixes (shared model base class, `whereDate()` instead of raw string comparison)