### PR TITLE
CodiceFiscaleCast

### DIFF
--- a/src/Laravel/Casts/CodiceFiscaleCast.php
+++ b/src/Laravel/Casts/CodiceFiscaleCast.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Laravel\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+
+/**
+ * @implements CastsAttributes<CodiceFiscale|null, CodiceFiscale|string|null>
+ */
+final class CodiceFiscaleCast implements CastsAttributes
+{
+    public function get($model, string $key, $value, array $attributes): ?CodiceFiscale
+    {
+        // Not just null: a non-string column value (wrong column type,
+        // driver quirk) is exactly the same kind of "data this cast
+        // doesn't recognize" that tryFrom() already handles for a
+        // malformed string - so it gets the same graceful null, not a
+        // TypeError from tryFrom() itself.
+        if (! is_string($value)) {
+            return null;
+        }
+
+        // tryFrom(), not from(): pre-existing invalid data (legacy
+        // rows, seeders, direct writes) must not make the model
+        // unusable to read - null surfaces it instead of throwing.
+        return CodiceFiscale::tryFrom($value);
+    }
+
+    public function set($model, string $key, $value, array $attributes): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof CodiceFiscale) {
+            return $value->value();
+        }
+
+        // from(), not tryFrom(): fail fast on assignment so
+        // structurally-invalid data can never enter the database
+        // through this cast in the first place.
+        return CodiceFiscale::from($value)->value();
+    }
+}

--- a/src/Laravel/Casts/CodiceFiscaleCast.php
+++ b/src/Laravel/Casts/CodiceFiscaleCast.php
@@ -4,9 +4,19 @@ namespace Robertogallea\CodiceFiscale\Laravel\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException;
 
 /**
- * @implements CastsAttributes<CodiceFiscale|null, CodiceFiscale|string|null>
+ * Intended usage is CodiceFiscale|string|null in, CodiceFiscale|null
+ * out - but TSet is declared as the honestly-permissive `mixed`, not
+ * that narrower promise: PHPStan doesn't enforce generics at runtime,
+ * and trusting a narrower declaration here previously led to removing
+ * a genuine defensive check (a caller can still assign an array/object
+ * via mass assignment from untrusted input). set() below validates
+ * the real range of what can arrive at runtime itself, rather than
+ * relying on a contract nothing actually enforces.
+ *
+ * @implements CastsAttributes<CodiceFiscale, mixed>
  */
 final class CodiceFiscaleCast implements CastsAttributes
 {
@@ -35,6 +45,12 @@ final class CodiceFiscaleCast implements CastsAttributes
 
         if ($value instanceof CodiceFiscale) {
             return $value->value();
+        }
+
+        if (! is_string($value)) {
+            throw new InvalidCodiceFiscaleException(
+                'fiscal_code casts only accept a string or a CodiceFiscale instance.'
+            );
         }
 
         // from(), not tryFrom(): fail fast on assignment so

--- a/tests/Feature/CodiceFiscaleCastTest.php
+++ b/tests/Feature/CodiceFiscaleCastTest.php
@@ -38,6 +38,15 @@ test('setting a structurally-invalid value throws immediately on assignment', fu
     expect(CastTestModel::count())->toBe(0);
 });
 
+test('setting a non-string, non-CodiceFiscale value throws rather than leaking a raw TypeError', function () {
+    // CastsAttributes::set()'s $value is untyped (mixed) at the real
+    // interface level - PHP never enforces a docblock generic at
+    // runtime, so a caller can still assign something else entirely
+    // (e.g. via mass assignment from untrusted array/request data).
+    expect(fn () => CastTestModel::create(['fiscal_code' => ['not', 'a', 'string']]))
+        ->toThrow(InvalidCodiceFiscaleException::class);
+});
+
 test('a null value round-trips to null without invoking validation', function () {
     $model = CastTestModel::create(['fiscal_code' => null]);
     $fresh = CastTestModel::find($model->id);

--- a/tests/Feature/CodiceFiscaleCastTest.php
+++ b/tests/Feature/CodiceFiscaleCastTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException;
+use Tests\Support\CastTestModel;
+
+beforeEach(function () {
+    Schema::create('cast_test_models', function (Blueprint $table) {
+        $table->id();
+        $table->string('fiscal_code')->nullable();
+    });
+});
+
+test('a structurally well-formed value round-trips to a CodiceFiscale instance', function () {
+    $model = CastTestModel::create(['fiscal_code' => 'RSSMRA95E05F205Z']);
+    $fresh = CastTestModel::find($model->id);
+
+    expect($fresh->fiscal_code)->toBeInstanceOf(CodiceFiscale::class)
+        ->and($fresh->fiscal_code->value())->toBe('RSSMRA95E05F205Z');
+});
+
+test('assigning a CodiceFiscale instance directly also round-trips correctly', function () {
+    $model = CastTestModel::create(['fiscal_code' => CodiceFiscale::from('RSSMRA95E05F205Z')]);
+    $fresh = CastTestModel::find($model->id);
+
+    expect($fresh->fiscal_code->value())->toBe('RSSMRA95E05F205Z');
+});
+
+test('setting a structurally-invalid value throws immediately on assignment', function () {
+    expect(fn () => CastTestModel::create(['fiscal_code' => 'not-a-real-code']))
+        ->toThrow(InvalidCodiceFiscaleException::class);
+
+    // Nothing was ever written to the database - fail-fast means fail
+    // before the insert, not a partially-written row.
+    expect(CastTestModel::count())->toBe(0);
+});
+
+test('a null value round-trips to null without invoking validation', function () {
+    $model = CastTestModel::create(['fiscal_code' => null]);
+    $fresh = CastTestModel::find($model->id);
+
+    expect($fresh->fiscal_code)->toBeNull();
+});
+
+test('reading a model whose column already holds an invalid string returns null, not an exception', function () {
+    // Bypassing the cast entirely, exactly like a legacy row, a seeder,
+    // or a direct write outside this package would.
+    $id = DB::table('cast_test_models')->insertGetId(['fiscal_code' => 'not-a-real-code']);
+
+    $model = CastTestModel::find($id);
+
+    expect($model->fiscal_code)->toBeNull();
+});

--- a/tests/Support/CastTestModel.php
+++ b/tests/Support/CastTestModel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Robertogallea\CodiceFiscale\Laravel\Casts\CodiceFiscaleCast;
+
+/**
+ * A minimal model on the host app's own default connection - not our
+ * dedicated 'codicefiscale' connection - since CodiceFiscaleCast is
+ * meant to be used on a consuming application's own models.
+ */
+final class CastTestModel extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = ['fiscal_code'];
+
+    protected function casts(): array
+    {
+        return [
+            'fiscal_code' => CodiceFiscaleCast::class,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `CodiceFiscaleCast`, the Eloquent cast for a `fiscal_code`-style attribute (#86, part of #75).
- `set()` fails fast: a structurally-invalid string throws `InvalidCodiceFiscaleException` immediately on assignment; a `CodiceFiscale` instance or well-formed string is accepted.
- `get()` is lenient: pre-existing invalid data in the column (legacy rows, seeders, direct writes) returns `null` on read rather than throwing.
- Reviewed via `/code-review` (Standards + Spec axes). Standards flagged that an `is_string()` guard in `set()` had been removed to satisfy a PHPStan "unreachable code" complaint, trusting a narrow `@implements CastsAttributes<CodiceFiscale|null, CodiceFiscale|string|null>` docblock generic — but PHP never enforces docblock generics at runtime, and the real interface's `$value` is `mixed` (confirmed by reading Laravel's actual `CastsAttributes` source). Fixed by declaring the honest `@implements CastsAttributes<CodiceFiscale, mixed>` and restoring the real runtime guard, which now throws a clear domain exception instead of leaking a raw `TypeError` for e.g. array/object mass-assignment.

## Acceptance criteria

- [x] Setting a structurally well-formed value on a cast attribute round-trips to a `CodiceFiscale` instance on read.
- [x] Setting a structurally-invalid value throws immediately on assignment.
- [x] Reading a model whose underlying column already holds an invalid string (inserted outside the cast) returns `null` rather than throwing.

## Test plan

- [x] `composer test` — 182 tests passing, 821 assertions
- [x] `composer phpstan` — clean at level `max`
- [x] `php-cs-fixer` — clean, no files needed fixing
- [x] New regression test: assigning a non-string, non-`CodiceFiscale` value (e.g. an array) throws `InvalidCodiceFiscaleException` rather than a raw `TypeError`