### PR TITLE
CodiceFiscaleRule

### DIFF
--- a/src/Laravel/CodiceFiscaleServiceProvider.php
+++ b/src/Laravel/CodiceFiscaleServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Robertogallea\CodiceFiscale\Laravel;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 use Illuminate\Database\Migrations\Migrator;
@@ -14,6 +15,7 @@ use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\EloquentBirthPlaceRepository
 use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\ForeignCountry;
 use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\Municipality;
 use Robertogallea\CodiceFiscale\Laravel\Commands\UpdatePlacesCommand;
+use Robertogallea\CodiceFiscale\Validation\Validator as CodiceFiscaleValidator;
 
 class CodiceFiscaleServiceProvider extends ServiceProvider
 {
@@ -39,6 +41,7 @@ class CodiceFiscaleServiceProvider extends ServiceProvider
         // since they're resolved lazily, well after boot() completes.
         $this->registerDatabaseConnection();
         $this->migrate();
+        $this->registerValidationRule();
 
         $this->publishes([
             $this->packagePath('config/codicefiscale.php') => config_path('codicefiscale.php'),
@@ -120,6 +123,21 @@ class CodiceFiscaleServiceProvider extends ServiceProvider
         } finally {
             $db->setDefaultConnection($originalDefaultConnection);
         }
+    }
+
+    /**
+     * The 2.x-retained convenience alias: format/checksum/semantics
+     * only, exactly what CodiceFiscaleRule::make() alone does, for
+     * callers who just need a plain pipe-delimited rule string.
+     */
+    private function registerValidationRule(): void
+    {
+        $this->app->make(ValidationFactory::class)->extend(
+            'codice_fiscale',
+            fn ($attribute, $value) => is_string($value)
+                && $this->app->make(CodiceFiscaleValidator::class)->validate($value)->valid(),
+            'The :attribute is not a valid codice fiscale.',
+        );
     }
 
     private function packagePath(string $path): string

--- a/src/Laravel/Rules/CodiceFiscaleRule.php
+++ b/src/Laravel/Rules/CodiceFiscaleRule.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Robertogallea\CodiceFiscale\Laravel\Rules;
+
+use Closure;
+use DateTimeImmutable;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\PartialPerson;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Enums\PersonField;
+use Robertogallea\CodiceFiscale\Matching\Matcher;
+use Robertogallea\CodiceFiscale\Validation\Validator;
+
+/**
+ * make() alone validates format/checksum/semantics via Validator -
+ * exactly what the codice_fiscale string-rule alias does. matching()
+ * additionally cross-checks the field against other request fields
+ * (by field name, via DataAwareRule::setData()) through Matcher, so
+ * a caller never has to encode multiple field names into one
+ * pipe-delimited rule string.
+ */
+final class CodiceFiscaleRule implements DataAwareRule, ValidationRule
+{
+    /** @var array<string, mixed> */
+    private array $data = [];
+
+    private ?string $firstNameField = null;
+
+    private ?string $lastNameField = null;
+
+    private ?string $birthDateField = null;
+
+    private ?string $birthPlaceField = null;
+
+    private ?string $genderField = null;
+
+    public function __construct(
+        private readonly Validator $validator,
+        private readonly Matcher $matcher,
+    ) {
+    }
+
+    public static function make(): self
+    {
+        return new self(app(Validator::class), app(Matcher::class));
+    }
+
+    public function matching(
+        ?string $firstName = null,
+        ?string $lastName = null,
+        ?string $birthDate = null,
+        ?string $birthPlace = null,
+        ?string $gender = null,
+    ): self {
+        $this->firstNameField = $firstName;
+        $this->lastNameField = $lastName;
+        $this->birthDateField = $birthDate;
+        $this->birthPlaceField = $birthPlace;
+        $this->genderField = $gender;
+
+        return $this;
+    }
+
+    /** @param array<string, mixed> $data */
+    public function setData(array $data): static
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || ! $this->validator->validate($value)->valid()) {
+            $fail('The :attribute is not a valid codice fiscale.');
+
+            return;
+        }
+
+        if (! $this->hasMatchingFields()) {
+            return;
+        }
+
+        $result = $this->matcher->match(CodiceFiscale::from($value), $this->partialPersonFromData());
+
+        if ($result->mismatched() !== []) {
+            $fail(sprintf(
+                'The :attribute does not match the provided %s.',
+                implode(', ', array_map($this->fieldName(...), $result->mismatched())),
+            ));
+        }
+    }
+
+    private function hasMatchingFields(): bool
+    {
+        return $this->firstNameField !== null
+            || $this->lastNameField !== null
+            || $this->birthDateField !== null
+            || $this->birthPlaceField !== null
+            || $this->genderField !== null;
+    }
+
+    private function partialPersonFromData(): PartialPerson
+    {
+        return new PartialPerson(
+            firstName: $this->stringFromData($this->firstNameField),
+            lastName: $this->stringFromData($this->lastNameField),
+            birthDate: $this->birthDateFromData(),
+            birthPlace: $this->birthPlaceFromData(),
+            gender: $this->genderFromData(),
+        );
+    }
+
+    private function stringFromData(?string $field): ?string
+    {
+        if ($field === null) {
+            return null;
+        }
+
+        $raw = $this->data[$field] ?? null;
+
+        return is_string($raw) ? $raw : null;
+    }
+
+    private function birthDateFromData(): ?DateTimeImmutable
+    {
+        $raw = $this->stringFromData($this->birthDateField);
+
+        if ($raw === null) {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable($raw);
+        } catch (\Exception) {
+            // An unparseable date can't be compared to anything -
+            // treated the same as "not provided" (skipped by Matcher)
+            // rather than forcing a spurious mismatch on a value
+            // that never reached a comparable form.
+            return null;
+        }
+    }
+
+    private function birthPlaceFromData(): ?BirthPlaceCode
+    {
+        $raw = $this->stringFromData($this->birthPlaceField);
+
+        return $raw === null ? null : BirthPlaceCode::tryFrom($raw);
+    }
+
+    private function genderFromData(): ?Gender
+    {
+        $raw = $this->stringFromData($this->genderField);
+
+        return $raw === null ? null : Gender::tryFrom(strtoupper($raw));
+    }
+
+    private function fieldName(PersonField $field): string
+    {
+        return match ($field) {
+            PersonField::FirstName => $this->firstNameField,
+            PersonField::LastName => $this->lastNameField,
+            PersonField::BirthDate => $this->birthDateField,
+            PersonField::BirthPlace => $this->birthPlaceField,
+            PersonField::Gender => $this->genderField,
+        } ?? $field->name;
+    }
+}

--- a/src/Laravel/Rules/CodiceFiscaleRule.php
+++ b/src/Laravel/Rules/CodiceFiscaleRule.php
@@ -21,21 +21,21 @@ use Robertogallea\CodiceFiscale\Validation\Validator;
  * (by field name, via DataAwareRule::setData()) through Matcher, so
  * a caller never has to encode multiple field names into one
  * pipe-delimited rule string.
+ *
+ * A field named via matching() that is either absent from the request
+ * data or holds a value that can't be parsed into what Matcher
+ * expects (an unparseable date, an unrecognized gender/birthplace
+ * code) is treated as not provided - PartialPerson's "skipped" bucket
+ * - rather than forced into a spurious mismatch on a value that never
+ * reached a comparable form.
  */
 final class CodiceFiscaleRule implements DataAwareRule, ValidationRule
 {
     /** @var array<string, mixed> */
     private array $data = [];
 
-    private ?string $firstNameField = null;
-
-    private ?string $lastNameField = null;
-
-    private ?string $birthDateField = null;
-
-    private ?string $birthPlaceField = null;
-
-    private ?string $genderField = null;
+    /** @var array<string, string> request field name, keyed by PersonField::name */
+    private array $fieldNames = [];
 
     public function __construct(
         private readonly Validator $validator,
@@ -55,11 +55,13 @@ final class CodiceFiscaleRule implements DataAwareRule, ValidationRule
         ?string $birthPlace = null,
         ?string $gender = null,
     ): self {
-        $this->firstNameField = $firstName;
-        $this->lastNameField = $lastName;
-        $this->birthDateField = $birthDate;
-        $this->birthPlaceField = $birthPlace;
-        $this->genderField = $gender;
+        $this->fieldNames = array_filter([
+            PersonField::FirstName->name => $firstName,
+            PersonField::LastName->name => $lastName,
+            PersonField::BirthDate->name => $birthDate,
+            PersonField::BirthPlace->name => $birthPlace,
+            PersonField::Gender->name => $gender,
+        ], static fn (?string $value): bool => $value !== null);
 
         return $this;
     }
@@ -80,7 +82,7 @@ final class CodiceFiscaleRule implements DataAwareRule, ValidationRule
             return;
         }
 
-        if (! $this->hasMatchingFields()) {
+        if ($this->fieldNames === []) {
             return;
         }
 
@@ -94,40 +96,33 @@ final class CodiceFiscaleRule implements DataAwareRule, ValidationRule
         }
     }
 
-    private function hasMatchingFields(): bool
-    {
-        return $this->firstNameField !== null
-            || $this->lastNameField !== null
-            || $this->birthDateField !== null
-            || $this->birthPlaceField !== null
-            || $this->genderField !== null;
-    }
-
     private function partialPersonFromData(): PartialPerson
     {
         return new PartialPerson(
-            firstName: $this->stringFromData($this->firstNameField),
-            lastName: $this->stringFromData($this->lastNameField),
+            firstName: $this->stringFromData(PersonField::FirstName),
+            lastName: $this->stringFromData(PersonField::LastName),
             birthDate: $this->birthDateFromData(),
             birthPlace: $this->birthPlaceFromData(),
             gender: $this->genderFromData(),
         );
     }
 
-    private function stringFromData(?string $field): ?string
+    private function stringFromData(PersonField $field): ?string
     {
-        if ($field === null) {
+        $fieldName = $this->fieldNames[$field->name] ?? null;
+
+        if ($fieldName === null) {
             return null;
         }
 
-        $raw = $this->data[$field] ?? null;
+        $raw = $this->data[$fieldName] ?? null;
 
         return is_string($raw) ? $raw : null;
     }
 
     private function birthDateFromData(): ?DateTimeImmutable
     {
-        $raw = $this->stringFromData($this->birthDateField);
+        $raw = $this->stringFromData(PersonField::BirthDate);
 
         if ($raw === null) {
             return null;
@@ -136,36 +131,26 @@ final class CodiceFiscaleRule implements DataAwareRule, ValidationRule
         try {
             return new DateTimeImmutable($raw);
         } catch (\Exception) {
-            // An unparseable date can't be compared to anything -
-            // treated the same as "not provided" (skipped by Matcher)
-            // rather than forcing a spurious mismatch on a value
-            // that never reached a comparable form.
             return null;
         }
     }
 
     private function birthPlaceFromData(): ?BirthPlaceCode
     {
-        $raw = $this->stringFromData($this->birthPlaceField);
+        $raw = $this->stringFromData(PersonField::BirthPlace);
 
         return $raw === null ? null : BirthPlaceCode::tryFrom($raw);
     }
 
     private function genderFromData(): ?Gender
     {
-        $raw = $this->stringFromData($this->genderField);
+        $raw = $this->stringFromData(PersonField::Gender);
 
         return $raw === null ? null : Gender::tryFrom(strtoupper($raw));
     }
 
     private function fieldName(PersonField $field): string
     {
-        return match ($field) {
-            PersonField::FirstName => $this->firstNameField,
-            PersonField::LastName => $this->lastNameField,
-            PersonField::BirthDate => $this->birthDateField,
-            PersonField::BirthPlace => $this->birthPlaceField,
-            PersonField::Gender => $this->genderField,
-        } ?? $field->name;
+        return $this->fieldNames[$field->name] ?? $field->name;
     }
 }

--- a/tests/Feature/CodiceFiscaleRuleTest.php
+++ b/tests/Feature/CodiceFiscaleRuleTest.php
@@ -176,3 +176,19 @@ test('the codice_fiscale string-rule alias fails a semantically-invalid value (u
 
     expect($result->fails())->toBeTrue();
 });
+
+test('->matching() treats an unparseable gender/birthplace value as skipped, not a mismatch', function () {
+    seedPalermo();
+    $cf = (new Generator())->generate(marioRossi());
+
+    $result = LaravelValidator::make(
+        [
+            'fiscal_code' => $cf->value(),
+            'sesso' => 'not-a-gender',
+            'luogo_nascita' => 'not-a-code',
+        ],
+        ['fiscal_code' => [CodiceFiscaleRule::make()->matching(gender: 'sesso', birthPlace: 'luogo_nascita')]],
+    );
+
+    expect($result->passes())->toBeTrue();
+});

--- a/tests/Feature/CodiceFiscaleRuleTest.php
+++ b/tests/Feature/CodiceFiscaleRuleTest.php
@@ -1,0 +1,178 @@
+<?php
+
+use Illuminate\Support\Facades\Validator as LaravelValidator;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\Person;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Generation\Generator;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\Municipality;
+use Robertogallea\CodiceFiscale\Laravel\Rules\CodiceFiscaleRule;
+
+function seedPalermo(): void
+{
+    Municipality::create([
+        'code' => 'F205', 'name' => 'PALERMO', 'province' => 'PA',
+        'istat_code' => '082053', 'valid_from' => '1861-01-01', 'valid_to' => null,
+    ]);
+}
+
+function marioRossi(): Person
+{
+    return new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1995-05-05'),
+        birthPlace: BirthPlaceCode::from('F205'),
+        gender: Gender::Male,
+    );
+}
+
+test('CodiceFiscaleRule::make() alone passes a structurally, checksum, and semantically valid code', function () {
+    seedPalermo();
+    $cf = (new Generator())->generate(marioRossi());
+
+    $result = LaravelValidator::make(
+        ['fiscal_code' => $cf->value()],
+        ['fiscal_code' => [CodiceFiscaleRule::make()]],
+    );
+
+    expect($result->passes())->toBeTrue();
+});
+
+test('CodiceFiscaleRule::make() alone fails a structurally malformed value', function () {
+    $result = LaravelValidator::make(
+        ['fiscal_code' => 'not-a-real-code'],
+        ['fiscal_code' => [CodiceFiscaleRule::make()]],
+    );
+
+    expect($result->fails())->toBeTrue();
+});
+
+test('CodiceFiscaleRule::make() alone fails a checksum-invalid value', function () {
+    seedPalermo();
+    $cf = (new Generator())->generate(marioRossi());
+    $tampered = substr($cf->value(), 0, -1).($cf->value()[-1] === 'Z' ? 'A' : 'Z');
+
+    $result = LaravelValidator::make(
+        ['fiscal_code' => $tampered],
+        ['fiscal_code' => [CodiceFiscaleRule::make()]],
+    );
+
+    expect($result->fails())->toBeTrue();
+});
+
+test('CodiceFiscaleRule::make() alone fails a semantically-invalid value (unrecognized birthplace code)', function () {
+    // Palermo is never seeded here, so a structurally/checksum-valid
+    // code encoding it must still fail on the semantics tier.
+    $cf = (new Generator())->generate(marioRossi());
+
+    $result = LaravelValidator::make(
+        ['fiscal_code' => $cf->value()],
+        ['fiscal_code' => [CodiceFiscaleRule::make()]],
+    );
+
+    expect($result->fails())->toBeTrue();
+});
+
+test('->matching() passes when every supplied field matches the code', function () {
+    seedPalermo();
+    $cf = (new Generator())->generate(marioRossi());
+
+    $result = LaravelValidator::make(
+        [
+            'fiscal_code' => $cf->value(),
+            'nome' => 'Mario',
+            'cognome' => 'Rossi',
+            'data_nascita' => '1995-05-05',
+            'luogo_nascita' => 'F205',
+            'sesso' => 'M',
+        ],
+        ['fiscal_code' => [CodiceFiscaleRule::make()->matching(
+            firstName: 'nome',
+            lastName: 'cognome',
+            birthDate: 'data_nascita',
+            birthPlace: 'luogo_nascita',
+            gender: 'sesso',
+        )]],
+    );
+
+    expect($result->passes())->toBeTrue();
+});
+
+test('->matching() fails on a mismatched field and reports which field failed', function () {
+    seedPalermo();
+    $cf = (new Generator())->generate(marioRossi());
+
+    $result = LaravelValidator::make(
+        [
+            'fiscal_code' => $cf->value(),
+            'sesso' => 'F',
+        ],
+        ['fiscal_code' => [CodiceFiscaleRule::make()->matching(gender: 'sesso')]],
+    );
+
+    expect($result->fails())->toBeTrue()
+        ->and($result->errors()->first('fiscal_code'))->toContain('sesso');
+});
+
+test('->matching() with a field absent from the request data is treated as skipped, not a mismatch', function () {
+    seedPalermo();
+    $cf = (new Generator())->generate(marioRossi());
+
+    $result = LaravelValidator::make(
+        ['fiscal_code' => $cf->value()],
+        ['fiscal_code' => [CodiceFiscaleRule::make()->matching(gender: 'sesso')]],
+    );
+
+    expect($result->passes())->toBeTrue();
+});
+
+test('->matching() reports every mismatched field, not just the first', function () {
+    seedPalermo();
+    $cf = (new Generator())->generate(marioRossi());
+
+    $result = LaravelValidator::make(
+        [
+            'fiscal_code' => $cf->value(),
+            'nome' => 'Luigi',
+            'sesso' => 'F',
+        ],
+        ['fiscal_code' => [CodiceFiscaleRule::make()->matching(firstName: 'nome', gender: 'sesso')]],
+    );
+
+    expect($result->fails())->toBeTrue()
+        ->and($result->errors()->first('fiscal_code'))->toContain('nome')
+        ->and($result->errors()->first('fiscal_code'))->toContain('sesso');
+});
+
+test('the codice_fiscale string-rule alias passes a valid code without the fluent builder', function () {
+    seedPalermo();
+    $cf = (new Generator())->generate(marioRossi());
+
+    $result = LaravelValidator::make(
+        ['fiscal_code' => $cf->value()],
+        ['fiscal_code' => 'codice_fiscale'],
+    );
+
+    expect($result->passes())->toBeTrue();
+});
+
+test('the codice_fiscale string-rule alias fails a structurally malformed value', function () {
+    $result = LaravelValidator::make(
+        ['fiscal_code' => 'not-a-real-code'],
+        ['fiscal_code' => 'codice_fiscale'],
+    );
+
+    expect($result->fails())->toBeTrue();
+});
+
+test('the codice_fiscale string-rule alias fails a semantically-invalid value (unrecognized birthplace code)', function () {
+    $cf = (new Generator())->generate(marioRossi());
+
+    $result = LaravelValidator::make(
+        ['fiscal_code' => $cf->value()],
+        ['fiscal_code' => 'codice_fiscale'],
+    );
+
+    expect($result->fails())->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Implements `CodiceFiscaleRule` (#87, part of #75): a fluent `CodiceFiscaleRule::make()->matching(firstName:, lastName:, birthDate:, birthPlace:, gender:)` Laravel validation rule wired to `Matcher`, plus the `codice_fiscale` string-rule convenience alias retained from 2.x.
- `make()` alone (no `->matching()`) validates format/checksum/semantics only, via `Validator` — exactly what the `codice_fiscale` string-rule alias does for callers who don't need the fluent builder.
- `->matching(...)` takes the *names* of other request fields (via `DataAwareRule::setData()`), cross-checks them against the codice fiscale through `Matcher`, and fails with a message naming every mismatched field, not just the first.
- A named field that's absent from the request data, or holds a value that can't be parsed into what `Matcher` expects (an unparseable date, an unrecognized gender/birthplace code), is treated as skipped rather than forced into a spurious mismatch.
- Reviewed via `/code-review` (Standards + Spec axes):
  - Standards flagged the five parallel nullable `*Field` properties as a data clump traveling together across four methods — collapsed into a single field-name map keyed by `PersonField`, which also removed the now-redundant `hasMatchingFields()` helper. (The duplicated format/checksum/semantics predicate between the rule and the service-provider's `codice_fiscale` string-alias closure was left as-is — it's an already-documented tradeoff of Illuminate's `extend()` boolean-closure contract vs. `ValidationRule`'s `$fail`-closure contract, not an oversight.)
  - Spec review found the skip-on-unparseable-value behavior was documented for `birthDate` but not for `gender`/`birthPlace` (which silently downgrade the same way via `tryFrom()`), and that no test covered a malformed - as opposed to merely wrong - gender/birthplace value under `->matching()`. Documented the behavior once at the class level and added the missing test.

## Acceptance criteria

- [x] `CodiceFiscaleRule::make()` alone (no `->matching()`) validates format/checksum/semantics only, via `Validator`.
- [x] `->matching(...)` cross-checks the field against other request fields via `Matcher`, failing validation on any mismatched field and reporting which field(s) failed.
- [x] The `codice_fiscale` string-rule alias continues to work for simple format/checksum/semantics validation without the fluent builder.

## Test plan

- [x] `composer test` — 194 tests passing, 836 assertions
- [x] `composer phpstan` — clean at level `max`
- [x] `php-cs-fixer` — clean, no files needed fixing
- [x] New tests cover: `make()` alone (valid/malformed/checksum-invalid/semantically-invalid), `->matching()` full match, single mismatch with field-name reporting, absent field treated as skipped, multiple mismatches all reported, unparseable gender/birthplace treated as skipped, and the `codice_fiscale` string-rule alias (valid/malformed/semantically-invalid)