### PR TITLE
UPGRADE.md + README rewrite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ laravel-codicefiscale is a package for parsing, generating, and validating the I
 ## Requirements
 
 - PHP ^8.2
-- Laravel (`illuminate/database`, `illuminate/support`) ^11.0 or ^12.0
+- Laravel (`illuminate/database`, `illuminate/support`) ^12.0 or ^13.0
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ laravel-codicefiscale is a package for parsing, generating, and validating the I
 - [Core domain](#core-domain)
   - [`CodiceFiscale`](#codicefiscale)
   - [Generation](#generation)
+  - [Customizing generation and parsing](#customizing-generation-and-parsing)
   - [Parsing](#parsing)
   - [Validation](#validation)
   - [Matching against a person](#matching-against-a-person)
@@ -128,6 +129,35 @@ $cf->value(); // 'RSSMRA85D15H501T'
 ```
 
 Name normalization (accents, apostrophes, mixed case, extra whitespace) happens automatically inside `Generator` — pass names exactly as the person typed them.
+
+### Customizing generation and parsing
+
+`Generator` composes four internal, independently-tested services — `NameEncoder`, `DateEncoder`, `BirthPlaceEncoder`, `Checksum` — plus a swappable `Contracts\NameNormalizer` (default `ItalianNameNormalizer`, handling Latin-script accents/apostrophes/whitespace), all as constructor parameters with defaults. Supply your own `NameNormalizer` if you need different text-cleanup behavior (e.g. broader multi-script transliteration):
+
+```php
+use Robertogallea\CodiceFiscale\Contracts\NameNormalizer;
+
+final class MyNormalizer implements NameNormalizer
+{
+    public function normalize(string $name): string { /* ... */ }
+}
+
+$cf = (new Generator(nameNormalizer: new MyNormalizer()))->generate($person);
+```
+
+Similarly, `Parser` resolves a codice fiscale's ambiguous two-digit birth year via a swappable `Contracts\CenturyResolver` (default `AgeBasedCenturyResolver(maxAge: 120)`, preferring the youngest plausible reading). Supply your own when you have domain-specific knowledge the default can't have:
+
+```php
+use Robertogallea\CodiceFiscale\Contracts\CenturyResolver;
+
+final class Post1970Resolver implements CenturyResolver
+{
+    // e.g. "this system only ever has customers born after 1970"
+    public function resolve(array $possibleYears): int { /* ... */ }
+}
+
+$parser = new Parser(app(BirthPlaceRepository::class), centuryResolver: new Post1970Resolver());
+```
 
 ### Parsing
 
@@ -239,7 +269,9 @@ $place = $repository->find(BirthPlaceCode::from('H501'), new DateTimeImmutable('
 $repository->existedEver(BirthPlaceCode::from('A999')); // false — distinguishes "never valid" from "valid, wrong date"
 ```
 
-`BirthPlaceCode::isForeign(): bool` tells domestic (Italian) codes apart from `Z`-prefixed foreign ones. The default `BirthPlaceRepository` binding is `Laravel\BirthPlaces\CompositeBirthPlaceRepository`, which routes to an Eloquent-backed repository per kind — populated by [`codice-fiscale:update-places`](#codice-fiscaleupdate-places).
+`BirthPlaceCode::isForeign(): bool` tells domestic (Italian) codes apart from `Z`-prefixed foreign ones; `BirthPlaceCode::equals(BirthPlaceCode $other): bool` compares two codes by value. `CountryCode` (an ISO 3166-1 alpha-3 string, e.g. `'USA'`) works the same way — `CountryCode::from()`/`tryFrom()` construct it, `equals()` compares it; it's a value object rather than a PHP enum since ~200 countries would make an enum unmaintainable.
+
+The default `BirthPlaceRepository` binding is `Laravel\BirthPlaces\CompositeBirthPlaceRepository`, which routes to an Eloquent-backed repository per kind — populated by [`codice-fiscale:update-places`](#codice-fiscaleupdate-places).
 
 ## Laravel integration
 

--- a/README.md
+++ b/README.md
@@ -4,348 +4,340 @@
 
 [![Author][ico-author]][link-author]
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/robertogallea/laravel-codicefiscale.svg?style=flat-square)](https://packagist.org/packages/robertogallea/laravel-codicefiscale)
-[![Laravel >=6.0][ico-laravel]][link-laravel]
 [![Software License][ico-license]](LICENSE.md)
 [![Sponsor me!][ico-sponsor]][link-sponsor]
 [![Packagist Downloads][ico-downloads]][link-downloads]
 
-laravel-codicefiscale is a package for the management of the Italian `CodiceFiscale` (i.e. tax code).
-The package allows easy validation and parsing of the CodiceFiscale. It is also suited for Laravel since it provides a
-convenient custom validator for request validation.
+laravel-codicefiscale is a package for parsing, generating, and validating the Italian `CodiceFiscale` (tax code). 3.0 is a ground-up rewrite: a small, framework-agnostic domain core (`Robertogallea\CodiceFiscale`) with immutable value objects and single-purpose services, plus a Laravel integration layer (`Robertogallea\CodiceFiscale\Laravel`) — a validation rule, an Eloquent cast, a Faker provider, and an artisan command backed by real Italian government data.
 
-## Laravel Version Compatibility
+> **Upgrading from 2.x?** 3.0 is an intentional, clean break with no compatibility shims. See [UPGRADE.md](UPGRADE.md) for a complete call-by-call migration table.
 
-| Laravel | Package |
-|---------|---------|
-| 12.x    | ^2.2    |
-| 11.x    | 2.x     |
-| 10.x    | 1.x     |
-| 9.x     | 1.x     |
-| 8.x     | 1.x     |
-| 7.x     | 1.x     |
-| 6.x     | 1.x     |
+## Requirements
 
-> **Important update**: now you can dynamically load city codes from ISTAT using the non-default `IstatRemoteCSVList`
-> city decoder.
+- PHP ^8.2
+- Laravel (`illuminate/database`, `illuminate/support`) ^11.0 or ^12.0
 
-- [Installation](#installation)
-- [Configuration](#configuration)
-- [Validation](#validation)
-- [Utility CodiceFiscale class](#utility-codicefiscale-class)
-- [Codice fiscale Generation](#codice-fiscale-generation)
-- [Faker integration](#faker-integration)
-- [City code parsing](#city-code-parsing)
-- [Integrate your own cities](#integrate-your-own-cities)
+## Table of contents
 
-## Installation
+- [Setup](#setup)
+- [Core domain](#core-domain)
+  - [`CodiceFiscale`](#codicefiscale)
+  - [Generation](#generation)
+  - [Parsing](#parsing)
+  - [Validation](#validation)
+  - [Matching against a person](#matching-against-a-person)
+  - [Omocodia](#omocodia)
+- [Birthplace domain](#birthplace-domain)
+- [Laravel integration](#laravel-integration)
+  - [Validation rule](#validation-rule)
+  - [Eloquent cast](#eloquent-cast)
+  - [Faker provider](#faker-provider)
+  - [`codice-fiscale:update-places`](#codice-fiscaleupdate-places)
 
-Run the following command to install the latest applicable version of the package:
+## Setup
 
 ```bash
-composer require robertogallea/laravel-codicefiscale:^2
+composer require robertogallea/laravel-codicefiscale:^3.0
 ```
 
-### Laravel
+The service provider is auto-discovered — no manual registration needed.
 
-In your app config, add the Service Provider to the `$providers` array *(only for Laravel 5.4 or below)*:
+Publish the config file if you want to customize it:
 
- ```php
-'providers' => [
-    ...
-    robertogallea\LaravelCodiceFiscale\CodiceFiscaleServiceProvider::class,
-],
+```bash
+php artisan vendor:publish --provider="Robertogallea\CodiceFiscale\Laravel\CodiceFiscaleServiceProvider" --tag="config"
 ```
-
-The validation error messages are translated in `it` and `en` languages, if you want to add new language please send me
-a PR.
-
-### Lumen
-
-In `bootstrap/app.php`, register the Service Provider
 
 ```php
-$app->register(robertogallea\LaravelCodiceFiscale\CodiceFiscaleServiceProvider::class);
+// config/codicefiscale.php
+
+return [
+    'database' => [
+        // Path to the dedicated SQLite database backing the
+        // birthplace repository. Never your application's own
+        // database — installing/using this package doesn't touch it.
+        'path' => storage_path('app/codicefiscale/places.sqlite'),
+    ],
+
+    // Sources for `codice-fiscale:update-places`. Only ever fetched
+    // when that command runs, never during normal validation.
+    'sources' => [
+        'municipalities' => 'https://www.anagrafenazionale.interno.it/wp-content/uploads/ANPR_archivio_comuni.csv',
+        'countries' => 'https://www.anagrafenazionale.interno.it/wp-content/uploads/tabella_2_statiesteri.xlsx',
+    ],
+];
 ```
 
-## Configuration
+Birthplace reference data (Italian municipalities and foreign countries) is never bundled with the package — nobody has verified the redistribution terms of the government datasets it comes from, so bundling a converted copy would mean redistributing it under this package's own unverified authority. Instead, each installation downloads its own copy:
 
-To customize the package configuration, you must export the configuration file into `config/codicefiscale.php`.
-
-This can be achieved by launching the following command:
-
-```
-php artisan vendor:publish --provider="robertogallea\LaravelCodiceFiscale\CodiceFiscaleServiceProvider" --tag="config"
+```bash
+php artisan codice-fiscale:update-places
 ```
 
-You can configure the following parameters:
+This populates the dedicated SQLite database configured above via a service-provider-managed migration and connection — it never touches your application's own database or migration bookkeeping. Run it once after installing, and again whenever you want fresher data. **Semantic validation and birthplace lookups return "unknown" until this has been run at least once.**
 
-- `city-decoder`: the class used for decoding city codes (see [City code parsing](#city-code-parsing)), default to
-  `InternationalCitiesStaticList`.
-- `date-format`: the date format used for parsing birthdates, default to `'Y-m-d'`.
-- `labels`: the labels used for `male` and `female` persons, defaults to `'M'` and `'F'`.
+Update just one dataset at a time if you don't need both refreshed:
 
-## Language Files
-
-You can customize the validation messages publishing the validation translations with this command:
-
-```
-php artisan vendor:publish --provider="robertogallea\LaravelCodiceFiscale\CodiceFiscaleServiceProvider" --tag="lang"
+```bash
+php artisan codice-fiscale:update-places --municipalities-only
+php artisan codice-fiscale:update-places --countries-only
 ```
 
-## Validation
+## Core domain
 
-To validate a codice fiscale, use the `codice_fiscale` keyword in your validation rules array
+Everything in this section lives under `Robertogallea\CodiceFiscale` and has no Laravel dependency — it works identically outside a Laravel application.
+
+### `CodiceFiscale`
+
+An immutable value object. It can only ever be constructed already structurally valid — there's no way to hold a malformed one:
 
 ```php
-    public function rules()
-    {
-        return [
-            'codicefiscale' => 'codice_fiscale',
-            
-            //...
-        ];
-    }
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException;
+
+$cf = CodiceFiscale::from('RSSMRA85D15H501T'); // throws InvalidCodiceFiscaleException if malformed
+$cf = CodiceFiscale::tryFrom('RSSMRA85D15H501T'); // returns null instead of throwing
+
+$cf->value(); // 'RSSMRA85D15H501T'
+(string) $cf; // same — CodiceFiscale implements Stringable
 ```
 
-From version **1.9.0** you can validate your codice fiscale against other form fields to check whether there is a match
-or not.
+`from()`/`tryFrom()` only check *structure* (length, character classes, valid-shaped fields) — not checksum or semantic correctness. See [Validation](#validation) for the rest.
 
-You must specify all of the required fields:
+### Generation
 
-- `first_name`
-- `last_name`
-- `birthdate`
-- `place`
-- `gender`
-
-giving parameters to the `codice_fiscale` rule.
-
-For example:
+`Generator` takes a `Person` and produces a `CodiceFiscale`:
 
 ```php
-    public function rules()
-    {
-        return [
-            'codicefiscale' => 'codice_fiscale:first_name=first_name_field,last_name=last_name_field,birthdate=birthdate_field,place=place_field,gender=gender_field',
-            'first_name_field' => 'required|string',
-            'last_name_field' => 'required|string',
-            'birthdate_field' => 'required|date',
-            'place_field' => 'required|string',
-            'gender_field' => 'required|string|max:1',
-            
-            //...
-        ];
-    }
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\Person;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Generation\Generator;
+
+$person = new Person(
+    firstName: 'Mario',
+    lastName: 'Rossi',
+    birthDate: new DateTimeImmutable('1985-04-15'),
+    birthPlace: BirthPlaceCode::from('H501'), // Roma
+    gender: Gender::Male,
+);
+
+$cf = (new Generator())->generate($person);
+
+$cf->value(); // 'RSSMRA85D15H501T'
 ```
 
-Validation fails if the provided codicefiscale and the one generated from the input fields do not match.
+Name normalization (accents, apostrophes, mixed case, extra whitespace) happens automatically inside `Generator` — pass names exactly as the person typed them.
 
-## Utility CodiceFiscale class
+### Parsing
 
-A codice fiscale can be wrapped in the `robertogallea\LaravelCodiceFiscale\CodiceFiscale` class to enhance it with
-useful utility methods.
+`Parser` decodes a `CodiceFiscale` back into its constituent parts. It needs a `Contracts\BirthPlaceRepository` to resolve birthplace codes to real records — in a Laravel app, resolve the one the service provider already binds:
 
 ```php
-use robertogallea\LaravelCodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Parsing\Parser;
 
-...
-try {
-    $cf = new CodiceFiscale();
-    $result = $cf->parse('RSSMRA95E05F205Z');
-    var_dump($result);
-} catch (Exception $exception) {
-    echo $exception;
+$parser = new Parser(app(BirthPlaceRepository::class));
+$parsed = $parser->parse($cf);
+
+$parsed->surnameCode();    // 'RSS' — a 3-character encoded fragment, NOT the real surname
+$parsed->nameCode();       // 'MRA' — same caveat
+$parsed->gender();         // Gender::Male
+$parsed->birthDate();      // DateTimeImmutable('1985-04-15'), or null if undecodable
+$parsed->birthYear();      // 1985
+$parsed->birthMonth();     // 4
+$parsed->birthDay();       // 15
+$parsed->birthPlaceCode(); // BirthPlaceCode('H501')
+$parsed->birthPlace();     // ?BirthPlace — null if the code isn't recognized, or update-places hasn't run
+$parsed->isOmocodia();     // false
+```
+
+There is no way to recover a person's real first/last name from a codice fiscale — `surnameCode()`/`nameCode()` are the same 3-character encoded fragments the algorithm itself works with, just honestly named (2.x's `getFirstName()`/`getLastName()` implied otherwise).
+
+Two-digit birth years are inherently ambiguous (`85` could mean 1885 or 1985); `Parser` resolves this automatically via `AgeBasedCenturyResolver` (preferring the youngest plausible reading, under a configurable `maxAge`), while still exposing `$parsed->possibleBirthYears(): array{int, int}` for callers who need to see or control the ambiguity themselves.
+
+### Validation
+
+`Validator` checks a raw string in independently-callable tiers, and never accepts a `Person` — "is this a valid codice fiscale" and "does this codice fiscale belong to this person" are deliberately separate concerns (see [Matching](#matching-against-a-person)):
+
+```php
+use Robertogallea\CodiceFiscale\Validation\Validator;
+
+$validator = new Validator(app(BirthPlaceRepository::class));
+
+$result = $validator->validate('RSSMRA85D15H501T');
+$result->valid();  // true
+$result->errors(); // []
+
+$result = $validator->validate('not-a-real-code');
+$result->valid();  // false
+$result->errors(); // [ValidationError::InvalidFormat]
+```
+
+`validate()` runs format as a gate (a malformed string can't safely be sliced further); once format passes, checksum and semantics run independently and both contribute to the same result, so a caller sees everything wrong with the input in one pass:
+
+```php
+$validator->validateFormat('RSSMRA85D15H501T');   // structural only
+$validator->validateChecksum($cf);                // needs a real CodiceFiscale, not a raw string
+$validator->validateSemantics($cf);                // valid calendar date + recognized birthplace + valid on that date
+```
+
+`ValidationError` is a backed enum: `InvalidFormat`, `InvalidChecksum`, `InvalidDate`, `UnknownBirthPlace`, `BirthPlaceNotValidOnDate` — not exceptions. Exceptions are reserved for genuine API misuse (e.g. `CodiceFiscale::from()` on malformed input), not expected validation failures.
+
+### Matching against a person
+
+`Matcher` cross-checks a `CodiceFiscale` against a `Person` (all fields required) or a `PartialPerson` (any subset):
+
+```php
+use Robertogallea\CodiceFiscale\Data\PartialPerson;
+use Robertogallea\CodiceFiscale\Matching\Matcher;
+
+$matcher = new Matcher(new Parser(app(BirthPlaceRepository::class)));
+
+$result = $matcher->match($cf, $person); // the same Person the code was generated from
+$result->matches();  // true
+$result->skipped();  // [] — every field was checked
+
+$result = $matcher->match($cf, new PartialPerson(firstName: 'Mario', gender: Gender::Female));
+$result->matches();    // false
+$result->matched();    // [PersonField::FirstName]
+$result->mismatched(); // [PersonField::Gender]
+$result->skipped();    // [PersonField::LastName, PersonField::BirthDate, PersonField::BirthPlace]
+```
+
+`MatchResult` distinguishes three explicit states, important when a match result feeds a compliance decision: **matched**, **mismatched**, and **skipped** (a field the `PartialPerson` simply didn't provide — never silently treated as a pass).
+
+### Omocodia
+
+When a computed codice fiscale collides with one already assigned, the Agenzia delle Entrate resolves it by substituting a subset of 7 fixed digit positions with letters. Any of the 2⁷ = 128 combinations may apply independently:
+
+```php
+use Robertogallea\CodiceFiscale\Omocodia\Omocodia;
+
+$omocodia = new Omocodia();
+
+$omocodia->canonical($cf);   // reverses all substitutions back to digits — pure, no repository needed
+$omocodia->level($cf);       // 0 — a count of substituted positions (0-7), not an ordinal/unique identifier
+$omocodia->variants($cf);    // iterable<CodiceFiscale> — all 128 combinations sharing $cf's underlying data
+
+$variant = CodiceFiscale::from('RSSMRA85D15H50ML'); // one substituted position vs. the canonical form
+$variant->isEquivalentTo($cf); // true — same canonical form, so the same person-derived data
+```
+
+## Birthplace domain
+
+`Contracts\BirthPlace` is a single time-bounded record: `code()`, `name()`, `validFrom()`, `validTo()` (null if still current), `wasValidOn(DateTimeImmutable)`. `DomesticBirthPlace` (Italian municipality) adds `province()`/`istatCode()`; `ForeignBirthPlace` (country) adds `country(): CountryCode`. A municipality that renamed or changed province produces multiple `BirthPlace` records sharing the same `BirthPlaceCode`, one per era — so a birth date tied to an old municipality identity still resolves correctly.
+
+```php
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+
+$repository = app(BirthPlaceRepository::class);
+
+$place = $repository->find(BirthPlaceCode::from('H501')); // valid today, or null
+$place = $repository->find(BirthPlaceCode::from('H501'), new DateTimeImmutable('1900-01-01')); // valid on that date
+
+$repository->existedEver(BirthPlaceCode::from('A999')); // false — distinguishes "never valid" from "valid, wrong date"
+```
+
+`BirthPlaceCode::isForeign(): bool` tells domestic (Italian) codes apart from `Z`-prefixed foreign ones. The default `BirthPlaceRepository` binding is `Laravel\BirthPlaces\CompositeBirthPlaceRepository`, which routes to an Eloquent-backed repository per kind — populated by [`codice-fiscale:update-places`](#codice-fiscaleupdate-places).
+
+## Laravel integration
+
+Everything in this section lives under `Robertogallea\CodiceFiscale\Laravel`.
+
+### Validation rule
+
+The `codice_fiscale` string rule checks format/checksum/semantics only:
+
+```php
+public function rules(): array
+{
+    return [
+        'fiscal_code' => 'codice_fiscale',
+    ];
 }
 ```
 
-In case of a valid codicefiscale it produces the following result:
+For cross-checking against other request fields, use the fluent `CodiceFiscaleRule`, naming the *other fields* to check against — not the values themselves:
 
 ```php
-[
-  "gender" => "M"
-  "birth_place" => "F205"
-  "birth_place_complete" => "Milano",
-  "day" => "05"
-  "month" => "05"
-  "year" => "1995"
-  "birthdate" => Carbon @799632000 {
-    date: 1995-05-05 00:00:00.0 UTC (+00:00)
-  }
-]
-```
+use Robertogallea\CodiceFiscale\Laravel\Rules\CodiceFiscaleRule;
 
-in case of an error, `CodiceFiscale::parse()` throws an `CodiceFiscaleValidationException`, which returns one of the
-defined constants with `$exception->getCode()`:
-
-- `CodiceFiscaleException::NO_ERROR`
-- `CodiceFiscaleException::NO_CODE`
-- `CodiceFiscaleException::WRONG_SIZE`
-- `CodiceFiscaleException::BAD_CHARACTERS`
-- `CodiceFiscaleException::BAD_OMOCODIA_CHAR`
-- `CodiceFiscaleException::WRONG_CODE`
-- `CodiceFiscaleException::MISSING_CITY_CODE`
-
-If you rather not want to catch exceptions, you can use `CodiceFiscale::tryParse()`:
-
-```php
-use robertogallea\LaravelCodiceFiscale\CodiceFiscale;
-
-...
-$cf = new CodiceFiscale();
-$result = $cf->tryParse('RSSMRA95E05F205Z');
-if ($result) {
-    var_dump($cf->asArray());
-} else {
-    echo $cf->getError();
+public function rules(): array
+{
+    return [
+        'fiscal_code' => [CodiceFiscaleRule::make()->matching(
+            firstName: 'first_name',
+            lastName: 'last_name',
+            birthDate: 'birth_date',
+            birthPlace: 'birth_place_code',
+            gender: 'gender',
+        )],
+    ];
 }
 ```
 
-which returns the same values as above, you can use `$cf->isValid()` to check if the codicefiscale is valid and
-`$cf->getError()` to get the error.
-This is especially useful in a blade template:
+Any argument can be omitted — an omitted field, or one absent from the request data, is skipped rather than forced into a mismatch. Validation fails with a message naming every mismatched field, not just the first.
+
+### Eloquent cast
+
+`CodiceFiscaleCast` rounds a `fiscal_code`-style attribute to a `CodiceFiscale` value object instead of a raw string:
 
 ```php
-@php($cf = new robertogallea\LaravelCodiceFiscale\CodiceFiscale())
-@if($cf->tryParse($codicefiscale))
-    <p><i class="fa fa-check" style="color:green"></i>{{$cf->getCodiceFiscale()}}</p>
-@else
-    <p><i class="fa fa-check" style="color:red"></i>{{$cf->getError()->getMessage()}}</p>
-@endif
+use Robertogallea\CodiceFiscale\Laravel\Casts\CodiceFiscaleCast;
+
+class Person extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'fiscal_code' => CodiceFiscaleCast::class,
+        ];
+    }
+}
+
+$person->fiscal_code; // CodiceFiscale|null
+
+$person->fiscal_code = 'RSSMRA85D15H501T'; // or a CodiceFiscale instance
+$person->fiscal_code = 'not-a-real-code'; // throws InvalidCodiceFiscaleException immediately
 ```
 
-## Codice fiscale Generation
+Setting a structurally-invalid value throws immediately (fail-fast at the ORM boundary) — bad data can't silently enter your database through the model layer. Reading a row whose stored value is invalid (legacy data, a seeder, a direct write outside the cast) returns `null` instead of throwing, so pre-existing bad data never makes the model unusable for inspection or cleanup.
 
-Class <code>CodiceFiscale</code> could be used to generate codice fiscale strings from input values:
+### Faker provider
 
-```php
-$first_name = 'Mario';
-$last_name = 'Rossi';
-$birth_date = '1995-05-05'; // or Carbon::parse('1995-05-05')
-$birth_place = 'F205';      // or 'Milano'
-$gender = 'M';
-
-$cf_string = CodiceFiscale::generate($first_name, $last_name, $birth_date, $birth_place, $gender);
-```
-
-## Faker integration
-
-You can generate fake codice fiscale in your factories using the provided faker extension:
+Auto-registered onto Laravel's `Faker\Generator` — no setup needed beyond installing the package:
 
 ```php
 class PersonFactory extends Factory
 {
-    
     public function definition(): array
     {
         return [
-            'first_name' => $firstName = fake()->firstName(),
-            'last_name' => $lastName = fake()->lastName(),
-            'fiscal_number' => fake()->codiceFiscale(firstName: $firstName, lastName: $lastName),
+            'fiscal_code' => fake()->codiceFiscale(),
         ];
     }
-```
-
-**Note**: you can provide some, all or none of the information required for the generation of codice fiscale
-(`firstName`, `lastName`, `birthDate`, `birthPlace`, `gender`)
-
-## City code parsing
-
-There are three strategies for decoding the city code:
-
-- `InternationalCitiesStaticList`: a static list of Italian cities;
-- `ItalianCitiesStaticList`: a static list of International cities;
-- `IstatRemoteCSVList`: a dynamic (loaded from web) list of Italian cities loaded from official ISTAT csv file.
-  Please note that the list is cached (one day by default, see config to change).
-- `CompositeCitiesList`: merge the results from two `CityDecoderInterface` classes (for example `IstatRemoteCSVList` and
-  `InternationalCitiesStaticList`) using the base `CityDecoderInterface` in the config key
-  `codicefiscale.cities-decoder-list`.
-
-By default, the package uses the class `InternationalCitiesStaticList` to lookup the city from the code and viceversa.
-However, you could use your own class to change the strategy used.
-
-You just need to implement the `CityDecoderInterface` and its `getList()` method.
-Then, to use it, just pass an instance to the `CodiceFiscale` class.
-
-For example:
-
-```php
-class MyCityList implements CityDecoderInterface
-{
-  public function getList()
-  {
-    // Implementation
-  }
 }
 ```
 
-```php
-...
-$cf = new CodiceFiscale(new MyCityList)
-...
-```
+`codiceFiscale()` takes no parameters — it always generates a fully random, valid `CodiceFiscale` via the real `Person`/`Generator` API, drawing its birthplace from a small, fixed set of ten well-known Italian municipalities bundled directly with the provider (not the full ANPR/MAECI dataset — see `docs/adr/0007-faker-provider-bundles-a-small-fixed-fact-list-not-birthplace-data.md`). It works in a fresh application that has never run `codice-fiscale:update-places`, since generation never touches a database at all.
 
-## Integrate your own cities
+If you need a code for a *specific* person rather than a random one, don't use the Faker provider — call `Generator` directly, as shown in [Generation](#generation).
 
-_Note_: if you find missing cities, please make a PR!
+### `codice-fiscale:update-places`
 
-If you want to integrate the cities list, you can use the `CompositeCitiesList` by merging the results of one of the
-decoders provided and a custom decoder.
-
-For example:
-
-```
-// conf/codicefiscale.php
-
-return [
-  'city-decoder' => '\robertogallea\LaravelCodiceFiscale\CityCodeDecoders\CompositeCitiesList',
-
-  ...
-  
-  'cities-decoder-list' => [
-        '\robertogallea\LaravelCodiceFiscale\CityCodeDecoders\InternationalCitiesStaticList',
-        'YourNamespace\MyCustomList',
-    ]
-```
-
-where `MyCustomList` is defined as:
-
-```
-...
-
-class MyCustomList implements CityDecoderInterface
-{
-  public function getList()
-  {
-    return [
-      'XYZ1' => 'My city 1',
-      'XYZ2' => 'My city 2',
-    ]
-  }
-}
-```
+Covered in [Setup](#setup). Downloads the ANPR comuni archive and MAECI stati-esteri table via Laravel's `Http` facade and upserts them into the dedicated SQLite database — safe to re-run at any time; existing rows are updated in place rather than duplicated.
 
 [ico-author]: https://img.shields.io/static/v1?label=author&message=robgallea&color=50ABF1&logo=twitter&style=flat-square
 
-[ico-release]: https://img.shields.io/github/v/release/robertogallea/laravel-codicefiscale
-
 [ico-downloads]: https://img.shields.io/packagist/dt/robertogallea/laravel-codicefiscale
-
-[ico-laravel]: https://img.shields.io/static/v1?label=laravel&message=%E2%89%A56.0&color=ff2d20&logo=laravel&style=flat-square
 
 [ico-sponsor]: https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&link=https://github.com/sponsors/robertogallea
 
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
 
-[ico-styleci]: https://styleci.io/repos/177130582/shield
-
 [link-author]: https://twitter.com/robgallea
-
-[link-release]: https://github.com/robertogallea/laravel-codicefiscale
 
 [link-downloads]: https://packagist.org/packages/robertogallea/laravel-codicefiscale
 
-[link-laravel]: https://laravel.com
-
 [link-sponsor]: https://github.com/sponsors/robertogallea
-
-[link-styleci]: https://styleci.io/repos/17713058s2/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Sponsor me!][ico-sponsor]][link-sponsor]
 [![Packagist Downloads][ico-downloads]][link-downloads]
 
-laravel-codicefiscale is a package for parsing, generating, and validating the Italian `CodiceFiscale` (tax code). 3.0 is a ground-up rewrite: a small, framework-agnostic domain core (`Robertogallea\CodiceFiscale`) with immutable value objects and single-purpose services, plus a Laravel integration layer (`Robertogallea\CodiceFiscale\Laravel`) — a validation rule, an Eloquent cast, a Faker provider, and an artisan command backed by real Italian government data.
+laravel-codicefiscale is a package for parsing, generating, and validating the Italian `CodiceFiscale` (tax code). 3.0 is a ground-up rewrite: a small, framework-agnostic domain core (`Robertogallea\CodiceFiscale`) with immutable value objects and single-purpose services, plus a Laravel integration layer (`Robertogallea\CodiceFiscale\Laravel`) - a validation rule, an Eloquent cast, a Faker provider, and an artisan command backed by real Italian government data.
 
 > **Upgrading from 2.x?** 3.0 is an intentional, clean break with no compatibility shims. See [UPGRADE.md](UPGRADE.md) for a complete call-by-call migration table.
 
@@ -41,7 +41,7 @@ laravel-codicefiscale is a package for parsing, generating, and validating the I
 composer require robertogallea/laravel-codicefiscale:^3.0
 ```
 
-The service provider is auto-discovered — no manual registration needed.
+The service provider is auto-discovered - no manual registration needed.
 
 Publish the config file if you want to customize it:
 
@@ -56,7 +56,7 @@ return [
     'database' => [
         // Path to the dedicated SQLite database backing the
         // birthplace repository. Never your application's own
-        // database — installing/using this package doesn't touch it.
+        // database - installing/using this package doesn't touch it.
         'path' => storage_path('app/codicefiscale/places.sqlite'),
     ],
 
@@ -69,13 +69,13 @@ return [
 ];
 ```
 
-Birthplace reference data (Italian municipalities and foreign countries) is never bundled with the package — nobody has verified the redistribution terms of the government datasets it comes from, so bundling a converted copy would mean redistributing it under this package's own unverified authority. Instead, each installation downloads its own copy:
+Birthplace reference data (Italian municipalities and foreign countries) is never bundled with the package - nobody has verified the redistribution terms of the government datasets it comes from, so bundling a converted copy would mean redistributing it under this package's own unverified authority. Instead, each installation downloads its own copy:
 
 ```bash
 php artisan codice-fiscale:update-places
 ```
 
-This populates the dedicated SQLite database configured above via a service-provider-managed migration and connection — it never touches your application's own database or migration bookkeeping. Run it once after installing, and again whenever you want fresher data. **Semantic validation and birthplace lookups return "unknown" until this has been run at least once.**
+This populates the dedicated SQLite database configured above via a service-provider-managed migration and connection - it never touches your application's own database or migration bookkeeping. Run it once after installing, and again whenever you want fresher data. **Semantic validation and birthplace lookups return "unknown" until this has been run at least once.**
 
 Update just one dataset at a time if you don't need both refreshed:
 
@@ -86,11 +86,11 @@ php artisan codice-fiscale:update-places --countries-only
 
 ## Core domain
 
-Everything in this section lives under `Robertogallea\CodiceFiscale` and has no Laravel dependency — it works identically outside a Laravel application.
+Everything in this section lives under `Robertogallea\CodiceFiscale` and has no Laravel dependency - it works identically outside a Laravel application.
 
 ### `CodiceFiscale`
 
-An immutable value object. It can only ever be constructed already structurally valid — there's no way to hold a malformed one:
+An immutable value object. It can only ever be constructed already structurally valid - there's no way to hold a malformed one:
 
 ```php
 use Robertogallea\CodiceFiscale\CodiceFiscale;
@@ -100,10 +100,10 @@ $cf = CodiceFiscale::from('RSSMRA85D15H501T'); // throws InvalidCodiceFiscaleExc
 $cf = CodiceFiscale::tryFrom('RSSMRA85D15H501T'); // returns null instead of throwing
 
 $cf->value(); // 'RSSMRA85D15H501T'
-(string) $cf; // same — CodiceFiscale implements Stringable
+(string) $cf; // same - CodiceFiscale implements Stringable
 ```
 
-`from()`/`tryFrom()` only check *structure* (length, character classes, valid-shaped fields) — not checksum or semantic correctness. See [Validation](#validation) for the rest.
+`from()`/`tryFrom()` only check *structure* (length, character classes, valid-shaped fields) - not checksum or semantic correctness. See [Validation](#validation) for the rest.
 
 ### Generation
 
@@ -128,11 +128,11 @@ $cf = (new Generator())->generate($person);
 $cf->value(); // 'RSSMRA85D15H501T'
 ```
 
-Name normalization (accents, apostrophes, mixed case, extra whitespace) happens automatically inside `Generator` — pass names exactly as the person typed them.
+Name normalization (accents, apostrophes, mixed case, extra whitespace) happens automatically inside `Generator` - pass names exactly as the person typed them.
 
 ### Customizing generation and parsing
 
-`Generator` composes four internal, independently-tested services — `NameEncoder`, `DateEncoder`, `BirthPlaceEncoder`, `Checksum` — plus a swappable `Contracts\NameNormalizer` (default `ItalianNameNormalizer`, handling Latin-script accents/apostrophes/whitespace), all as constructor parameters with defaults. Supply your own `NameNormalizer` if you need different text-cleanup behavior (e.g. broader multi-script transliteration):
+`Generator` composes four internal, independently-tested services - `NameEncoder`, `DateEncoder`, `BirthPlaceEncoder`, `Checksum` - plus a swappable `Contracts\NameNormalizer` (default `ItalianNameNormalizer`, handling Latin-script accents/apostrophes/whitespace), all as constructor parameters with defaults. Supply your own `NameNormalizer` if you need different text-cleanup behavior (e.g. broader multi-script transliteration):
 
 ```php
 use Robertogallea\CodiceFiscale\Contracts\NameNormalizer;
@@ -161,7 +161,7 @@ $parser = new Parser(app(BirthPlaceRepository::class), centuryResolver: new Post
 
 ### Parsing
 
-`Parser` decodes a `CodiceFiscale` back into its constituent parts. It needs a `Contracts\BirthPlaceRepository` to resolve birthplace codes to real records — in a Laravel app, resolve the one the service provider already binds:
+`Parser` decodes a `CodiceFiscale` back into its constituent parts. It needs a `Contracts\BirthPlaceRepository` to resolve birthplace codes to real records - in a Laravel app, resolve the one the service provider already binds:
 
 ```php
 use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
@@ -170,25 +170,25 @@ use Robertogallea\CodiceFiscale\Parsing\Parser;
 $parser = new Parser(app(BirthPlaceRepository::class));
 $parsed = $parser->parse($cf);
 
-$parsed->surnameCode();    // 'RSS' — a 3-character encoded fragment, NOT the real surname
-$parsed->nameCode();       // 'MRA' — same caveat
+$parsed->surnameCode();    // 'RSS' - a 3-character encoded fragment, NOT the real surname
+$parsed->nameCode();       // 'MRA' - same caveat
 $parsed->gender();         // Gender::Male
 $parsed->birthDate();      // DateTimeImmutable('1985-04-15'), or null if undecodable
 $parsed->birthYear();      // 1985
 $parsed->birthMonth();     // 4
 $parsed->birthDay();       // 15
 $parsed->birthPlaceCode(); // BirthPlaceCode('H501')
-$parsed->birthPlace();     // ?BirthPlace — null if the code isn't recognized, or update-places hasn't run
+$parsed->birthPlace();     // ?BirthPlace - null if the code isn't recognized, or update-places hasn't run
 $parsed->isOmocodia();     // false
 ```
 
-There is no way to recover a person's real first/last name from a codice fiscale — `surnameCode()`/`nameCode()` are the same 3-character encoded fragments the algorithm itself works with, just honestly named (2.x's `getFirstName()`/`getLastName()` implied otherwise).
+There is no way to recover a person's real first/last name from a codice fiscale - `surnameCode()`/`nameCode()` are the same 3-character encoded fragments the algorithm itself works with, just honestly named (2.x's `getFirstName()`/`getLastName()` implied otherwise).
 
 Two-digit birth years are inherently ambiguous (`85` could mean 1885 or 1985); `Parser` resolves this automatically via `AgeBasedCenturyResolver` (preferring the youngest plausible reading, under a configurable `maxAge`), while still exposing `$parsed->possibleBirthYears(): array{int, int}` for callers who need to see or control the ambiguity themselves.
 
 ### Validation
 
-`Validator` checks a raw string in independently-callable tiers, and never accepts a `Person` — "is this a valid codice fiscale" and "does this codice fiscale belong to this person" are deliberately separate concerns (see [Matching](#matching-against-a-person)):
+`Validator` checks a raw string in independently-callable tiers, and never accepts a `Person` - "is this a valid codice fiscale" and "does this codice fiscale belong to this person" are deliberately separate concerns (see [Matching](#matching-against-a-person)):
 
 ```php
 use Robertogallea\CodiceFiscale\Validation\Validator;
@@ -212,7 +212,7 @@ $validator->validateChecksum($cf);                // needs a real CodiceFiscale,
 $validator->validateSemantics($cf);                // valid calendar date + recognized birthplace + valid on that date
 ```
 
-`ValidationError` is a backed enum: `InvalidFormat`, `InvalidChecksum`, `InvalidDate`, `UnknownBirthPlace`, `BirthPlaceNotValidOnDate` — not exceptions. Exceptions are reserved for genuine API misuse (e.g. `CodiceFiscale::from()` on malformed input), not expected validation failures.
+`ValidationError` is a backed enum: `InvalidFormat`, `InvalidChecksum`, `InvalidDate`, `UnknownBirthPlace`, `BirthPlaceNotValidOnDate` - not exceptions. Exceptions are reserved for genuine API misuse (e.g. `CodiceFiscale::from()` on malformed input), not expected validation failures.
 
 ### Matching against a person
 
@@ -226,7 +226,7 @@ $matcher = new Matcher(new Parser(app(BirthPlaceRepository::class)));
 
 $result = $matcher->match($cf, $person); // the same Person the code was generated from
 $result->matches();  // true
-$result->skipped();  // [] — every field was checked
+$result->skipped();  // [] - every field was checked
 
 $result = $matcher->match($cf, new PartialPerson(firstName: 'Mario', gender: Gender::Female));
 $result->matches();    // false
@@ -235,7 +235,7 @@ $result->mismatched(); // [PersonField::Gender]
 $result->skipped();    // [PersonField::LastName, PersonField::BirthDate, PersonField::BirthPlace]
 ```
 
-`MatchResult` distinguishes three explicit states, important when a match result feeds a compliance decision: **matched**, **mismatched**, and **skipped** (a field the `PartialPerson` simply didn't provide — never silently treated as a pass).
+`MatchResult` distinguishes three explicit states, important when a match result feeds a compliance decision: **matched**, **mismatched**, and **skipped** (a field the `PartialPerson` simply didn't provide - never silently treated as a pass).
 
 ### Omocodia
 
@@ -246,17 +246,17 @@ use Robertogallea\CodiceFiscale\Omocodia\Omocodia;
 
 $omocodia = new Omocodia();
 
-$omocodia->canonical($cf);   // reverses all substitutions back to digits — pure, no repository needed
-$omocodia->level($cf);       // 0 — a count of substituted positions (0-7), not an ordinal/unique identifier
-$omocodia->variants($cf);    // iterable<CodiceFiscale> — all 128 combinations sharing $cf's underlying data
+$omocodia->canonical($cf);   // reverses all substitutions back to digits - pure, no repository needed
+$omocodia->level($cf);       // 0 - a count of substituted positions (0-7), not an ordinal/unique identifier
+$omocodia->variants($cf);    // iterable<CodiceFiscale> - all 128 combinations sharing $cf's underlying data
 
 $variant = CodiceFiscale::from('RSSMRA85D15H50ML'); // one substituted position vs. the canonical form
-$variant->isEquivalentTo($cf); // true — same canonical form, so the same person-derived data
+$variant->isEquivalentTo($cf); // true - same canonical form, so the same person-derived data
 ```
 
 ## Birthplace domain
 
-`Contracts\BirthPlace` is a single time-bounded record: `code()`, `name()`, `validFrom()`, `validTo()` (null if still current), `wasValidOn(DateTimeImmutable)`. `DomesticBirthPlace` (Italian municipality) adds `province()`/`istatCode()`; `ForeignBirthPlace` (country) adds `country(): CountryCode`. A municipality that renamed or changed province produces multiple `BirthPlace` records sharing the same `BirthPlaceCode`, one per era — so a birth date tied to an old municipality identity still resolves correctly.
+`Contracts\BirthPlace` is a single time-bounded record: `code()`, `name()`, `validFrom()`, `validTo()` (null if still current), `wasValidOn(DateTimeImmutable)`. `DomesticBirthPlace` (Italian municipality) adds `province()`/`istatCode()`; `ForeignBirthPlace` (country) adds `country(): CountryCode`. A municipality that renamed or changed province produces multiple `BirthPlace` records sharing the same `BirthPlaceCode`, one per era - so a birth date tied to an old municipality identity still resolves correctly.
 
 ```php
 use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
@@ -266,12 +266,12 @@ $repository = app(BirthPlaceRepository::class);
 $place = $repository->find(BirthPlaceCode::from('H501')); // valid today, or null
 $place = $repository->find(BirthPlaceCode::from('H501'), new DateTimeImmutable('1900-01-01')); // valid on that date
 
-$repository->existedEver(BirthPlaceCode::from('A999')); // false — distinguishes "never valid" from "valid, wrong date"
+$repository->existedEver(BirthPlaceCode::from('A999')); // false - distinguishes "never valid" from "valid, wrong date"
 ```
 
-`BirthPlaceCode::isForeign(): bool` tells domestic (Italian) codes apart from `Z`-prefixed foreign ones; `BirthPlaceCode::equals(BirthPlaceCode $other): bool` compares two codes by value. `CountryCode` (an ISO 3166-1 alpha-3 string, e.g. `'USA'`) works the same way — `CountryCode::from()`/`tryFrom()` construct it, `equals()` compares it; it's a value object rather than a PHP enum since ~200 countries would make an enum unmaintainable.
+`BirthPlaceCode::isForeign(): bool` tells domestic (Italian) codes apart from `Z`-prefixed foreign ones; `BirthPlaceCode::equals(BirthPlaceCode $other): bool` compares two codes by value. `CountryCode` (an ISO 3166-1 alpha-3 string, e.g. `'USA'`) works the same way - `CountryCode::from()`/`tryFrom()` construct it, `equals()` compares it; it's a value object rather than a PHP enum since ~200 countries would make an enum unmaintainable.
 
-The default `BirthPlaceRepository` binding is `Laravel\BirthPlaces\CompositeBirthPlaceRepository`, which routes to an Eloquent-backed repository per kind — populated by [`codice-fiscale:update-places`](#codice-fiscaleupdate-places).
+The default `BirthPlaceRepository` binding is `Laravel\BirthPlaces\CompositeBirthPlaceRepository`, which routes to an Eloquent-backed repository per kind - populated by [`codice-fiscale:update-places`](#codice-fiscaleupdate-places).
 
 ## Laravel integration
 
@@ -290,7 +290,7 @@ public function rules(): array
 }
 ```
 
-For cross-checking against other request fields, use the fluent `CodiceFiscaleRule`, naming the *other fields* to check against — not the values themselves:
+For cross-checking against other request fields, use the fluent `CodiceFiscaleRule`, naming the *other fields* to check against - not the values themselves:
 
 ```php
 use Robertogallea\CodiceFiscale\Laravel\Rules\CodiceFiscaleRule;
@@ -309,7 +309,7 @@ public function rules(): array
 }
 ```
 
-Any argument can be omitted — an omitted field, or one absent from the request data, is skipped rather than forced into a mismatch. Validation fails with a message naming every mismatched field, not just the first.
+Any argument can be omitted - an omitted field, or one absent from the request data, is skipped rather than forced into a mismatch. Validation fails with a message naming every mismatched field, not just the first.
 
 ### Eloquent cast
 
@@ -334,11 +334,11 @@ $person->fiscal_code = 'RSSMRA85D15H501T'; // or a CodiceFiscale instance
 $person->fiscal_code = 'not-a-real-code'; // throws InvalidCodiceFiscaleException immediately
 ```
 
-Setting a structurally-invalid value throws immediately (fail-fast at the ORM boundary) — bad data can't silently enter your database through the model layer. Reading a row whose stored value is invalid (legacy data, a seeder, a direct write outside the cast) returns `null` instead of throwing, so pre-existing bad data never makes the model unusable for inspection or cleanup.
+Setting a structurally-invalid value throws immediately (fail-fast at the ORM boundary) - bad data can't silently enter your database through the model layer. Reading a row whose stored value is invalid (legacy data, a seeder, a direct write outside the cast) returns `null` instead of throwing, so pre-existing bad data never makes the model unusable for inspection or cleanup.
 
 ### Faker provider
 
-Auto-registered onto Laravel's `Faker\Generator` — no setup needed beyond installing the package:
+Auto-registered onto Laravel's `Faker\Generator` - no setup needed beyond installing the package:
 
 ```php
 class PersonFactory extends Factory
@@ -352,13 +352,13 @@ class PersonFactory extends Factory
 }
 ```
 
-`codiceFiscale()` takes no parameters — it always generates a fully random, valid `CodiceFiscale` via the real `Person`/`Generator` API, drawing its birthplace from a small, fixed set of ten well-known Italian municipalities bundled directly with the provider (not the full ANPR/MAECI dataset — see `docs/adr/0007-faker-provider-bundles-a-small-fixed-fact-list-not-birthplace-data.md`). It works in a fresh application that has never run `codice-fiscale:update-places`, since generation never touches a database at all.
+`codiceFiscale()` takes no parameters - it always generates a fully random, valid `CodiceFiscale` via the real `Person`/`Generator` API, drawing its birthplace from a small, fixed set of ten well-known Italian municipalities bundled directly with the provider (not the full ANPR/MAECI dataset - see `docs/adr/0007-faker-provider-bundles-a-small-fixed-fact-list-not-birthplace-data.md`). It works in a fresh application that has never run `codice-fiscale:update-places`, since generation never touches a database at all.
 
-If you need a code for a *specific* person rather than a random one, don't use the Faker provider — call `Generator` directly, as shown in [Generation](#generation).
+If you need a code for a *specific* person rather than a random one, don't use the Faker provider - call `Generator` directly, as shown in [Generation](#generation).
 
 ### `codice-fiscale:update-places`
 
-Covered in [Setup](#setup). Downloads the ANPR comuni archive and MAECI stati-esteri table via Laravel's `Http` facade and upserts them into the dedicated SQLite database — safe to re-run at any time; existing rows are updated in place rather than duplicated.
+Covered in [Setup](#setup). Downloads the ANPR comuni archive and MAECI stati-esteri table via Laravel's `Http` facade and upserts them into the dedicated SQLite database - safe to re-run at any time; existing rows are updated in place rather than duplicated.
 
 [ico-author]: https://img.shields.io/static/v1?label=author&message=robgallea&color=50ABF1&logo=twitter&style=flat-square
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,47 +1,47 @@
 # Upgrading from 2.x to 3.0
 
-3.0 is an intentional, clean break from 2.x — there are no compatibility shims, and nothing from the `robertogallea\LaravelCodiceFiscale` namespace survives unchanged. This document maps every documented 2.x call to its 3.x equivalent. See [README.md](README.md) for the full 3.x API with usage examples, and `docs/adr/0001-clean-break-from-2x-api.md` for why this was done as a major version rather than incremental patches.
+3.0 is an intentional, clean break from 2.x - there are no compatibility shims, and nothing from the `robertogallea\LaravelCodiceFiscale` namespace survives unchanged. This document maps every documented 2.x call to its 3.x equivalent. See [README.md](README.md) for the full 3.x API with usage examples, and `docs/adr/0001-clean-break-from-2x-api.md` for why this was done as a major version rather than incremental patches.
 
 ## Why the break
 
-2.x's `CodiceFiscale` class mixed together parsing state, validation, birthplace/date/gender decoding, and person-matching in one mutable object — so "is this valid," "what does it decode to," and "does it match this person" couldn't be reasoned about separately. Its `getFirstName()`/`getLastName()` returned 3-character *encoded fragments*, not the person's real name, which was actively misleading. Century resolution for two-digit birth years used a heuristic 2.x itself acknowledged as broken. Birthplace data was a flat, current-day-only static list with no support for renamed/merged Italian municipalities. None of this could be fixed without breaking the documented 2.x API.
+2.x's `CodiceFiscale` class mixed together parsing state, validation, birthplace/date/gender decoding, and person-matching in one mutable object - so "is this valid," "what does it decode to," and "does it match this person" couldn't be reasoned about separately. Its `getFirstName()`/`getLastName()` returned 3-character *encoded fragments*, not the person's real name, which was actively misleading. Century resolution for two-digit birth years used a heuristic 2.x itself acknowledged as broken. Birthplace data was a flat, current-day-only static list with no support for renamed/merged Italian municipalities. None of this could be fixed without breaking the documented 2.x API.
 
 ## Namespace and package layout
 
 | 2.x | 3.x |
 |---|---|
 | `robertogallea\LaravelCodiceFiscale\*` (core + Laravel mixed together) | `Robertogallea\CodiceFiscale\*` for the framework-agnostic core; `Robertogallea\CodiceFiscale\Laravel\*` for everything Laravel-specific (service provider, Eloquent repository, validation rule, cast, Faker provider, artisan command). See `docs/adr/0002-framework-agnostic-core-namespace.md`. |
-| `robertogallea\LaravelCodiceFiscale\CodiceFiscaleServiceProvider` | `Robertogallea\CodiceFiscale\Laravel\CodiceFiscaleServiceProvider` (auto-discovered via `composer.json`'s `extra.laravel.providers` — manual registration is no longer needed on Laravel 5.5+) |
+| `robertogallea\LaravelCodiceFiscale\CodiceFiscaleServiceProvider` | `Robertogallea\CodiceFiscale\Laravel\CodiceFiscaleServiceProvider` (auto-discovered via `composer.json`'s `extra.laravel.providers` - manual registration is no longer needed on Laravel 5.5+) |
 
 ## One-time setup change
 
-2.x bundled a static city-code list, so it worked with zero setup. 3.0 sources real ANPR (Italian municipalities, with full rename/province-change history) and MAECI (foreign countries) government data instead of bundling a converted copy of it (`docs/adr/0003-no-bundled-birthplace-data.md`) — so **before any semantic validation or birthplace lookup will succeed**, run:
+2.x bundled a static city-code list, so it worked with zero setup. 3.0 sources real ANPR (Italian municipalities, with full rename/province-change history) and MAECI (foreign countries) government data instead of bundling a converted copy of it (`docs/adr/0003-no-bundled-birthplace-data.md`) - so **before any semantic validation or birthplace lookup will succeed**, run:
 
 ```bash
 php artisan codice-fiscale:update-places
 ```
 
-This downloads both datasets into your own application's dedicated SQLite database (never your primary database — see README's [Setup](README.md#setup) section). There is no 2.x equivalent to this step.
+This downloads both datasets into your own application's dedicated SQLite database (never your primary database - see README's [Setup](README.md#setup) section). There is no 2.x equivalent to this step.
 
 ## `CodiceFiscale` class
 
 | 2.x | 3.x | Notes |
 |---|---|---|
-| `new CodiceFiscale($cityDecoder?, $config?)` then `->parse($cf)` (throws `CodiceFiscaleValidationException`) | `CodiceFiscale::from(string $cf)` (throws `InvalidCodiceFiscaleException`) | Structural validation only — see `Validator` below for checksum/semantics. |
+| `new CodiceFiscale($cityDecoder?, $config?)` then `->parse($cf)` (throws `CodiceFiscaleValidationException`) | `CodiceFiscale::from(string $cf)` (throws `InvalidCodiceFiscaleException`) | Structural validation only - see `Validator` below for checksum/semantics. |
 | `->tryParse($cf): bool` | `CodiceFiscale::tryFrom(string $cf): ?CodiceFiscale` | Returns null instead of a boolean; no exception ever thrown. |
 | `->isValid(): bool` | `CodiceFiscale::tryFrom($cf) !== null` (structural only) or `Validator::validate($cf)->valid()` (full) | 2.x's `isValid()` mixed structural, checksum, and semantic validity into one boolean; 3.x separates them into named `Validator` tiers. |
-| `->getError(): ?\Exception` | `Validator::validate($cf)->errors(): list<ValidationError>` | An enum, not exceptions — exceptions are reserved for API misuse (e.g. `CodiceFiscale::from()` on malformed input), not expected validation failures. |
+| `->getError(): ?\Exception` | `Validator::validate($cf)->errors(): list<ValidationError>` | An enum, not exceptions - exceptions are reserved for API misuse (e.g. `CodiceFiscale::from()` on malformed input), not expected validation failures. |
 | `->getCodiceFiscale(): ?string` | `CodiceFiscale::value()` (or `(string) $cf`, since it implements `Stringable`) | |
 | `->getGender(): ?string` (`'M'`/`'F'`) | `ParsedCodiceFiscale::gender(): Gender` | `Gender` is a backed enum (`Gender::Male`/`Gender::Female`), not a configurable string label. |
 | `->getBirthPlace(): ?string` (4-char code) | `ParsedCodiceFiscale::birthPlaceCode(): BirthPlaceCode` | A value object, not a raw string. `->value()` gets the string back. |
 | `->getBirthPlaceComplete(): ?string` (threw `MISSING_CITY_CODE` if unknown) | `ParsedCodiceFiscale::birthPlace(): ?BirthPlace` | Returns null for an unrecognized code instead of throwing; `->name()` for the display name, and for a domestic record `->province()`/`->istatCode()`. Requires `codice-fiscale:update-places` to have populated the repository. |
 | `->isInternational(): bool` | `BirthPlaceCode::isForeign(): bool` | |
-| `->isItalian(): bool` | `! $birthPlaceCode->isForeign()` | No dedicated method — it was always the logical negation. |
-| `->getBirthdate(): Carbon` (threw on invalid) | `ParsedCodiceFiscale::birthDate(): ?DateTimeImmutable` | Nullable instead of throwing for an undecodable date (e.g. a nonexistent calendar day); plain `DateTimeImmutable`, not Carbon — the core package has no Carbon dependency. |
+| `->isItalian(): bool` | `! $birthPlaceCode->isForeign()` | No dedicated method - it was always the logical negation. |
+| `->getBirthdate(): Carbon` (threw on invalid) | `ParsedCodiceFiscale::birthDate(): ?DateTimeImmutable` | Nullable instead of throwing for an undecodable date (e.g. a nonexistent calendar day); plain `DateTimeImmutable`, not Carbon - the core package has no Carbon dependency. |
 | `->getYear(): ?string`, `->getMonth(): ?string`, `->getDay(): ?string` | `ParsedCodiceFiscale::birthYear(): int`, `->birthMonth(): int`, `->birthDay(): int` | Real integers. `birthDate()` gives you the assembled date directly in most cases. |
-| `->getFirstName(): ?string`, `->getLastName(): ?string` | `ParsedCodiceFiscale::nameCode(): string`, `->surnameCode(): string` | **Same 3-character encoded fragments as 2.x — just honestly named.** There has never been a way to recover a person's real first/last name from a codice fiscale; 2.x's method names implied otherwise. |
+| `->getFirstName(): ?string`, `->getLastName(): ?string` | `ParsedCodiceFiscale::nameCode(): string`, `->surnameCode(): string` | **Same 3-character encoded fragments as 2.x - just honestly named.** There has never been a way to recover a person's real first/last name from a codice fiscale; 2.x's method names implied otherwise. |
 | `->asArray(): array` | *(no equivalent)* | Read `ParsedCodiceFiscale`'s methods directly, or build your own array from them if you need one. |
-| `CodiceFiscale::generate($firstName, $lastName, $birthDate, $place, $gender, $config?): string` (static, primitive strings) | `(new Generator())->generate(new Person(firstName:, lastName:, birthDate:, birthPlace:, gender:)): CodiceFiscale` | Takes a `Person` DTO — a real `DateTimeImmutable`, a `BirthPlaceCode` value object, and a `Gender` enum case, not loosely-typed strings. Returns a `CodiceFiscale`, not a raw string (call `->value()` if you need the string). |
+| `CodiceFiscale::generate($firstName, $lastName, $birthDate, $place, $gender, $config?): string` (static, primitive strings) | `(new Generator())->generate(new Person(firstName:, lastName:, birthDate:, birthPlace:, gender:)): CodiceFiscale` | Takes a `Person` DTO - a real `DateTimeImmutable`, a `BirthPlaceCode` value object, and a `Gender` enum case, not loosely-typed strings. Returns a `CodiceFiscale`, not a raw string (call `->value()` if you need the string). |
 
 ## Exceptions and error codes
 
@@ -51,9 +51,9 @@ This downloads both datasets into your own application's dedicated SQLite databa
 |---|---|---|
 | `WRONG_SIZE`, `BAD_CHARACTERS`, `BAD_OMOCODIA_CHAR` | `ValidationError::InvalidFormat` | From `Validator::validateFormat()`. |
 | `WRONG_CODE` | `ValidationError::InvalidChecksum` | From `Validator::validateChecksum()`. |
-| `MISSING_CITY_CODE` | `ValidationError::UnknownBirthPlace` or `ValidationError::BirthPlaceNotValidOnDate` | From `Validator::validateSemantics()` — 3.x distinguishes "never a valid code" from "valid code, wrong date". |
+| `MISSING_CITY_CODE` | `ValidationError::UnknownBirthPlace` or `ValidationError::BirthPlaceNotValidOnDate` | From `Validator::validateSemantics()` - 3.x distinguishes "never a valid code" from "valid code, wrong date". |
 | *(no equivalent)* | `ValidationError::InvalidDate` | A structurally/checksum-valid code whose month/day don't form a real calendar date. |
-| `NO_MATCH`, `WRONG_FIRST_NAME`, `WRONG_LAST_NAME`, `WRONG_BIRTH_DAY`, `WRONG_BIRTH_MONTH`, `WRONG_BIRTH_YEAR`, `WRONG_BIRTH_PLACE`, `WRONG_GENDER` | `Matcher::match()->mismatched(): list<PersonField>` | Person-match failures are no longer folded into validation at all — `Validator` never accepts a `Person`, and `Matcher` never reports validation errors. See README's [Matching](README.md#matching-against-a-person) section. |
+| `NO_MATCH`, `WRONG_FIRST_NAME`, `WRONG_LAST_NAME`, `WRONG_BIRTH_DAY`, `WRONG_BIRTH_MONTH`, `WRONG_BIRTH_YEAR`, `WRONG_BIRTH_PLACE`, `WRONG_GENDER` | `Matcher::match()->mismatched(): list<PersonField>` | Person-match failures are no longer folded into validation at all - `Validator` never accepts a `Person`, and `Matcher` never reports validation errors. See README's [Matching](README.md#matching-against-a-person) section. |
 | `NO_CODE`, `NO_ERROR`, `EMPTY_BIRTHDATE` | *(genuine API misuse, not a validation outcome)* | e.g. passing an empty string to `CodiceFiscale::from()` throws `InvalidCodiceFiscaleException` directly, the same way any other malformed input does. |
 
 New, narrower exception types replace the single catch-all: `InvalidCodiceFiscaleException`, `InvalidBirthPlaceCodeException`, `InvalidCountryCodeException` (all `\InvalidArgumentException`), and `CodiceFiscaleGenerationException`.
@@ -63,10 +63,10 @@ New, narrower exception types replace the single catch-all: `InvalidCodiceFiscal
 | 2.x | 3.x | Notes |
 |---|---|---|
 | `CityDecoderInterface` (`getList(): array<code, name>`) | `Contracts\BirthPlaceRepository` (`find(BirthPlaceCode, ?DateTimeImmutable $on = null): ?BirthPlace`, `existedEver(BirthPlaceCode): bool`) | A repository with real dates, not a flat lookup table. |
-| `InternationalCitiesStaticList`, `ItalianCitiesStaticList` (bundled static lists) | *(no bundled equivalent — see `docs/adr/0003-no-bundled-birthplace-data.md`)* | Real ANPR/MAECI data is downloaded into your own database via `codice-fiscale:update-places` instead. |
+| `InternationalCitiesStaticList`, `ItalianCitiesStaticList` (bundled static lists) | *(no bundled equivalent - see `docs/adr/0003-no-bundled-birthplace-data.md`)* | Real ANPR/MAECI data is downloaded into your own database via `codice-fiscale:update-places` instead. |
 | `IstatRemoteCSVList` (dynamic ISTAT CSV fetch, cached) | `codice-fiscale:update-places` artisan command | One command instead of a request-time fetch-and-cache decoder; data lives in your own dedicated SQLite database, refreshed on demand rather than on a TTL. |
-| `CompositeCitiesList` (merges two decoders) | `Laravel\BirthPlaces\CompositeBirthPlaceRepository` | Routes domestic (non-`Z`) codes to a Municipality-backed repository and foreign (`Z`-prefixed) codes to a ForeignCountry-backed one — this is the default binding, not an opt-in merge strategy. |
-| A city name string (`getBirthPlaceComplete()`) with no history | `DomesticBirthPlace` (name, province, ISTAT code, `[validFrom, validTo)`) / `ForeignBirthPlace` (name, ISO 3166-1 alpha-3 `CountryCode`) | A municipality that renamed or changed province now produces multiple time-bounded `BirthPlace` records sharing the same `BirthPlaceCode` — a birth date tied to an old municipality identity resolves correctly instead of failing. |
+| `CompositeCitiesList` (merges two decoders) | `Laravel\BirthPlaces\CompositeBirthPlaceRepository` | Routes domestic (non-`Z`) codes to a Municipality-backed repository and foreign (`Z`-prefixed) codes to a ForeignCountry-backed one - this is the default binding, not an opt-in merge strategy. |
+| A city name string (`getBirthPlaceComplete()`) with no history | `DomesticBirthPlace` (name, province, ISTAT code, `[validFrom, validTo)`) / `ForeignBirthPlace` (name, ISO 3166-1 alpha-3 `CountryCode`) | A municipality that renamed or changed province now produces multiple time-bounded `BirthPlace` records sharing the same `BirthPlaceCode` - a birth date tied to an old municipality identity resolves correctly instead of failing. |
 | config `city-decoder` | *(removed)* | The default `BirthPlaceRepository` binding is fixed; implement the `BirthPlaceRepository` contract yourself and rebind it in your own service provider if you need a different source. |
 
 ## `CodiceFiscaleConfig`
@@ -80,26 +80,26 @@ Removed entirely (`getDateFormat()`, `getMaleLabel()`, `getFemaleLabel()`). Date
 | `city-decoder` | *(removed)* | |
 | `istat-csv-url` | `sources.municipalities` | Now the ANPR comuni-archive URL, not an ISTAT CSV. |
 | *(no equivalent)* | `sources.countries` | The MAECI stati-esteri table URL. |
-| `cache-duration` | *(removed)* | No request-time caching — data is fetched once per `update-places` run, not per-request. |
+| `cache-duration` | *(removed)* | No request-time caching - data is fetched once per `update-places` run, not per-request. |
 | `cities-decoder-list` | *(removed)* | |
 | `date-format` | *(removed)* | |
 | `labels.male` / `labels.female` | *(removed)* | |
-| *(no equivalent)* | `database.path` | Path to the dedicated SQLite database backing the birthplace repository — never your application's own database. |
+| *(no equivalent)* | `database.path` | Path to the dedicated SQLite database backing the birthplace repository - never your application's own database. |
 
 ## Validation rule
 
 | 2.x | 3.x | Notes |
 |---|---|---|
-| `'field' => 'codice_fiscale'` | `'field' => 'codice_fiscale'` | Unchanged — still format/checksum/semantics only. |
+| `'field' => 'codice_fiscale'` | `'field' => 'codice_fiscale'` | Unchanged - still format/checksum/semantics only. |
 | `'field' => 'codice_fiscale:first_name=first_name_field,last_name=last_name_field,birthdate=birthdate_field,place=place_field,gender=gender_field'` | `'field' => [CodiceFiscaleRule::make()->matching(firstName: 'first_name_field', lastName: 'last_name_field', birthDate: 'birthdate_field', birthPlace: 'place_field', gender: 'gender_field')]` | Named arguments to a fluent builder instead of encoding five field names into one pipe-delimited string. |
 
 ## Faker integration
 
 | 2.x | 3.x | Notes |
 |---|---|---|
-| `fake()->codiceFiscale(firstName: ?, lastName: ?, birthDate: ?, gender: ?, birthPlace: ?)` — every parameter optional, unset ones randomized | `fake()->codiceFiscale(): string` — no parameters | Always fully random, drawing from a small bundled set of well-known municipalities (see README's [Faker provider](README.md#faker-provider) section). If you need a code for a *specific* person, don't use the Faker provider — call `(new Generator())->generate(new Person(...))` directly, exactly what the provider itself does internally. |
+| `fake()->codiceFiscale(firstName: ?, lastName: ?, birthDate: ?, gender: ?, birthPlace: ?)` - every parameter optional, unset ones randomized | `fake()->codiceFiscale(): string` - no parameters | Always fully random, drawing from a small bundled set of well-known municipalities (see README's [Faker provider](README.md#faker-provider) section). If you need a code for a *specific* person, don't use the Faker provider - call `(new Generator())->generate(new Person(...))` directly, exactly what the provider itself does internally. |
 
 ## New in 3.x, nothing to migrate
 
-- `CodiceFiscaleCast` — an Eloquent cast so a `fiscal_code`-style model attribute round-trips as a `CodiceFiscale` value object. 2.x had no cast; codice fiscale columns were always raw strings.
-- `Omocodia` service (`canonical()`, `variants()`, `level()`) and `CodiceFiscale::isEquivalentTo()` — 2.x decoded omocodia substitutions internally as an implementation detail of `parse()`, with no public API to generate variants or compare two codes for the same underlying person.
+- `CodiceFiscaleCast` - an Eloquent cast so a `fiscal_code`-style model attribute round-trips as a `CodiceFiscale` value object. 2.x had no cast; codice fiscale columns were always raw strings.
+- `Omocodia` service (`canonical()`, `variants()`, `level()`) and `CodiceFiscale::isEquivalentTo()` - 2.x decoded omocodia substitutions internally as an implementation detail of `parse()`, with no public API to generate variants or compare two codes for the same underlying person.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,105 @@
+# Upgrading from 2.x to 3.0
+
+3.0 is an intentional, clean break from 2.x — there are no compatibility shims, and nothing from the `robertogallea\LaravelCodiceFiscale` namespace survives unchanged. This document maps every documented 2.x call to its 3.x equivalent. See [README.md](README.md) for the full 3.x API with usage examples, and `docs/adr/0001-clean-break-from-2x-api.md` for why this was done as a major version rather than incremental patches.
+
+## Why the break
+
+2.x's `CodiceFiscale` class mixed together parsing state, validation, birthplace/date/gender decoding, and person-matching in one mutable object — so "is this valid," "what does it decode to," and "does it match this person" couldn't be reasoned about separately. Its `getFirstName()`/`getLastName()` returned 3-character *encoded fragments*, not the person's real name, which was actively misleading. Century resolution for two-digit birth years used a heuristic 2.x itself acknowledged as broken. Birthplace data was a flat, current-day-only static list with no support for renamed/merged Italian municipalities. None of this could be fixed without breaking the documented 2.x API.
+
+## Namespace and package layout
+
+| 2.x | 3.x |
+|---|---|
+| `robertogallea\LaravelCodiceFiscale\*` (core + Laravel mixed together) | `Robertogallea\CodiceFiscale\*` for the framework-agnostic core; `Robertogallea\CodiceFiscale\Laravel\*` for everything Laravel-specific (service provider, Eloquent repository, validation rule, cast, Faker provider, artisan command). See `docs/adr/0002-framework-agnostic-core-namespace.md`. |
+| `robertogallea\LaravelCodiceFiscale\CodiceFiscaleServiceProvider` | `Robertogallea\CodiceFiscale\Laravel\CodiceFiscaleServiceProvider` (auto-discovered via `composer.json`'s `extra.laravel.providers` — manual registration is no longer needed on Laravel 5.5+) |
+
+## One-time setup change
+
+2.x bundled a static city-code list, so it worked with zero setup. 3.0 sources real ANPR (Italian municipalities, with full rename/province-change history) and MAECI (foreign countries) government data instead of bundling a converted copy of it (`docs/adr/0003-no-bundled-birthplace-data.md`) — so **before any semantic validation or birthplace lookup will succeed**, run:
+
+```bash
+php artisan codice-fiscale:update-places
+```
+
+This downloads both datasets into your own application's dedicated SQLite database (never your primary database — see README's [Setup](README.md#setup) section). There is no 2.x equivalent to this step.
+
+## `CodiceFiscale` class
+
+| 2.x | 3.x | Notes |
+|---|---|---|
+| `new CodiceFiscale($cityDecoder?, $config?)` then `->parse($cf)` (throws `CodiceFiscaleValidationException`) | `CodiceFiscale::from(string $cf)` (throws `InvalidCodiceFiscaleException`) | Structural validation only — see `Validator` below for checksum/semantics. |
+| `->tryParse($cf): bool` | `CodiceFiscale::tryFrom(string $cf): ?CodiceFiscale` | Returns null instead of a boolean; no exception ever thrown. |
+| `->isValid(): bool` | `CodiceFiscale::tryFrom($cf) !== null` (structural only) or `Validator::validate($cf)->valid()` (full) | 2.x's `isValid()` mixed structural, checksum, and semantic validity into one boolean; 3.x separates them into named `Validator` tiers. |
+| `->getError(): ?\Exception` | `Validator::validate($cf)->errors(): list<ValidationError>` | An enum, not exceptions — exceptions are reserved for API misuse (e.g. `CodiceFiscale::from()` on malformed input), not expected validation failures. |
+| `->getCodiceFiscale(): ?string` | `CodiceFiscale::value()` (or `(string) $cf`, since it implements `Stringable`) | |
+| `->getGender(): ?string` (`'M'`/`'F'`) | `ParsedCodiceFiscale::gender(): Gender` | `Gender` is a backed enum (`Gender::Male`/`Gender::Female`), not a configurable string label. |
+| `->getBirthPlace(): ?string` (4-char code) | `ParsedCodiceFiscale::birthPlaceCode(): BirthPlaceCode` | A value object, not a raw string. `->value()` gets the string back. |
+| `->getBirthPlaceComplete(): ?string` (threw `MISSING_CITY_CODE` if unknown) | `ParsedCodiceFiscale::birthPlace(): ?BirthPlace` | Returns null for an unrecognized code instead of throwing; `->name()` for the display name, and for a domestic record `->province()`/`->istatCode()`. Requires `codice-fiscale:update-places` to have populated the repository. |
+| `->isInternational(): bool` | `BirthPlaceCode::isForeign(): bool` | |
+| `->isItalian(): bool` | `! $birthPlaceCode->isForeign()` | No dedicated method — it was always the logical negation. |
+| `->getBirthdate(): Carbon` (threw on invalid) | `ParsedCodiceFiscale::birthDate(): ?DateTimeImmutable` | Nullable instead of throwing for an undecodable date (e.g. a nonexistent calendar day); plain `DateTimeImmutable`, not Carbon — the core package has no Carbon dependency. |
+| `->getYear(): ?string`, `->getMonth(): ?string`, `->getDay(): ?string` | `ParsedCodiceFiscale::birthYear(): int`, `->birthMonth(): int`, `->birthDay(): int` | Real integers. `birthDate()` gives you the assembled date directly in most cases. |
+| `->getFirstName(): ?string`, `->getLastName(): ?string` | `ParsedCodiceFiscale::nameCode(): string`, `->surnameCode(): string` | **Same 3-character encoded fragments as 2.x — just honestly named.** There has never been a way to recover a person's real first/last name from a codice fiscale; 2.x's method names implied otherwise. |
+| `->asArray(): array` | *(no equivalent)* | Read `ParsedCodiceFiscale`'s methods directly, or build your own array from them if you need one. |
+| `CodiceFiscale::generate($firstName, $lastName, $birthDate, $place, $gender, $config?): string` (static, primitive strings) | `(new Generator())->generate(new Person(firstName:, lastName:, birthDate:, birthPlace:, gender:)): CodiceFiscale` | Takes a `Person` DTO — a real `DateTimeImmutable`, a `BirthPlaceCode` value object, and a `Gender` enum case, not loosely-typed strings. Returns a `CodiceFiscale`, not a raw string (call `->value()` if you need the string). |
+
+## Exceptions and error codes
+
+2.x's single `CodiceFiscaleValidationException` carried a numeric error code (`NO_CODE`, `WRONG_SIZE`, `BAD_CHARACTERS`, `BAD_OMOCODIA_CHAR`, `WRONG_CODE`, `MISSING_CITY_CODE`, `NO_MATCH`, `EMPTY_BIRTHDATE`, `WRONG_FIRST_NAME`, `WRONG_LAST_NAME`, `WRONG_BIRTH_DAY`, `WRONG_BIRTH_MONTH`, `WRONG_BIRTH_YEAR`, `WRONG_BIRTH_PLACE`, `WRONG_GENDER`) mixing structural, checksum, semantic, *and* person-match failures into one type.
+
+| 2.x | 3.x | Notes |
+|---|---|---|
+| `WRONG_SIZE`, `BAD_CHARACTERS`, `BAD_OMOCODIA_CHAR` | `ValidationError::InvalidFormat` | From `Validator::validateFormat()`. |
+| `WRONG_CODE` | `ValidationError::InvalidChecksum` | From `Validator::validateChecksum()`. |
+| `MISSING_CITY_CODE` | `ValidationError::UnknownBirthPlace` or `ValidationError::BirthPlaceNotValidOnDate` | From `Validator::validateSemantics()` — 3.x distinguishes "never a valid code" from "valid code, wrong date". |
+| *(no equivalent)* | `ValidationError::InvalidDate` | A structurally/checksum-valid code whose month/day don't form a real calendar date. |
+| `NO_MATCH`, `WRONG_FIRST_NAME`, `WRONG_LAST_NAME`, `WRONG_BIRTH_DAY`, `WRONG_BIRTH_MONTH`, `WRONG_BIRTH_YEAR`, `WRONG_BIRTH_PLACE`, `WRONG_GENDER` | `Matcher::match()->mismatched(): list<PersonField>` | Person-match failures are no longer folded into validation at all — `Validator` never accepts a `Person`, and `Matcher` never reports validation errors. See README's [Matching](README.md#matching-against-a-person) section. |
+| `NO_CODE`, `NO_ERROR`, `EMPTY_BIRTHDATE` | *(genuine API misuse, not a validation outcome)* | e.g. passing an empty string to `CodiceFiscale::from()` throws `InvalidCodiceFiscaleException` directly, the same way any other malformed input does. |
+
+New, narrower exception types replace the single catch-all: `InvalidCodiceFiscaleException`, `InvalidBirthPlaceCodeException`, `InvalidCountryCodeException` (all `\InvalidArgumentException`), and `CodiceFiscaleGenerationException`.
+
+## City code decoding → BirthPlace domain
+
+| 2.x | 3.x | Notes |
+|---|---|---|
+| `CityDecoderInterface` (`getList(): array<code, name>`) | `Contracts\BirthPlaceRepository` (`find(BirthPlaceCode, ?DateTimeImmutable $on = null): ?BirthPlace`, `existedEver(BirthPlaceCode): bool`) | A repository with real dates, not a flat lookup table. |
+| `InternationalCitiesStaticList`, `ItalianCitiesStaticList` (bundled static lists) | *(no bundled equivalent — see `docs/adr/0003-no-bundled-birthplace-data.md`)* | Real ANPR/MAECI data is downloaded into your own database via `codice-fiscale:update-places` instead. |
+| `IstatRemoteCSVList` (dynamic ISTAT CSV fetch, cached) | `codice-fiscale:update-places` artisan command | One command instead of a request-time fetch-and-cache decoder; data lives in your own dedicated SQLite database, refreshed on demand rather than on a TTL. |
+| `CompositeCitiesList` (merges two decoders) | `Laravel\BirthPlaces\CompositeBirthPlaceRepository` | Routes domestic (non-`Z`) codes to a Municipality-backed repository and foreign (`Z`-prefixed) codes to a ForeignCountry-backed one — this is the default binding, not an opt-in merge strategy. |
+| A city name string (`getBirthPlaceComplete()`) with no history | `DomesticBirthPlace` (name, province, ISTAT code, `[validFrom, validTo)`) / `ForeignBirthPlace` (name, ISO 3166-1 alpha-3 `CountryCode`) | A municipality that renamed or changed province now produces multiple time-bounded `BirthPlace` records sharing the same `BirthPlaceCode` — a birth date tied to an old municipality identity resolves correctly instead of failing. |
+| config `city-decoder` | *(removed)* | The default `BirthPlaceRepository` binding is fixed; implement the `BirthPlaceRepository` contract yourself and rebind it in your own service provider if you need a different source. |
+
+## `CodiceFiscaleConfig`
+
+Removed entirely (`getDateFormat()`, `getMaleLabel()`, `getFemaleLabel()`). Dates are always `DateTimeImmutable` (no format string to configure), and gender is always the `Gender` enum (no configurable string labels).
+
+## `config/codicefiscale.php`
+
+| 2.x key | 3.x key | Notes |
+|---|---|---|
+| `city-decoder` | *(removed)* | |
+| `istat-csv-url` | `sources.municipalities` | Now the ANPR comuni-archive URL, not an ISTAT CSV. |
+| *(no equivalent)* | `sources.countries` | The MAECI stati-esteri table URL. |
+| `cache-duration` | *(removed)* | No request-time caching — data is fetched once per `update-places` run, not per-request. |
+| `cities-decoder-list` | *(removed)* | |
+| `date-format` | *(removed)* | |
+| `labels.male` / `labels.female` | *(removed)* | |
+| *(no equivalent)* | `database.path` | Path to the dedicated SQLite database backing the birthplace repository — never your application's own database. |
+
+## Validation rule
+
+| 2.x | 3.x | Notes |
+|---|---|---|
+| `'field' => 'codice_fiscale'` | `'field' => 'codice_fiscale'` | Unchanged — still format/checksum/semantics only. |
+| `'field' => 'codice_fiscale:first_name=first_name_field,last_name=last_name_field,birthdate=birthdate_field,place=place_field,gender=gender_field'` | `'field' => [CodiceFiscaleRule::make()->matching(firstName: 'first_name_field', lastName: 'last_name_field', birthDate: 'birthdate_field', birthPlace: 'place_field', gender: 'gender_field')]` | Named arguments to a fluent builder instead of encoding five field names into one pipe-delimited string. |
+
+## Faker integration
+
+| 2.x | 3.x | Notes |
+|---|---|---|
+| `fake()->codiceFiscale(firstName: ?, lastName: ?, birthDate: ?, gender: ?, birthPlace: ?)` — every parameter optional, unset ones randomized | `fake()->codiceFiscale(): string` — no parameters | Always fully random, drawing from a small bundled set of well-known municipalities (see README's [Faker provider](README.md#faker-provider) section). If you need a code for a *specific* person, don't use the Faker provider — call `(new Generator())->generate(new Person(...))` directly, exactly what the provider itself does internally. |
+
+## New in 3.x, nothing to migrate
+
+- `CodiceFiscaleCast` — an Eloquent cast so a `fiscal_code`-style model attribute round-trips as a `CodiceFiscale` value object. 2.x had no cast; codice fiscale columns were always raw strings.
+- `Omocodia` service (`canonical()`, `variants()`, `level()`) and `CodiceFiscale::isEquivalentTo()` — 2.x decoded omocodia substitutions internally as an implementation detail of `parse()`, with no public API to generate variants or compare two codes for the same underlying person.

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/database": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/database": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.0",
         "pestphp/pest": "^3.0",
-        "orchestra/testbench": "^10.1",
+        "orchestra/testbench": "^10.1|^11.0",
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^2.0",
         "fakerphp/faker": "^1.20"

--- a/src/Laravel/BirthPlaces/Import/UpsertsInChunks.php
+++ b/src/Laravel/BirthPlaces/Import/UpsertsInChunks.php
@@ -16,7 +16,7 @@ trait UpsertsInChunks
      * @param  list<array<string, string>>  $rows
      * @param  callable(array<string, string>): array<string, string|null>  $toRecord
      * @param  class-string<Model>  $modelClass
-     * @param  list<string>  $uniqueBy
+     * @param  non-empty-list<non-empty-string>  $uniqueBy
      * @param  list<string>  $update
      * @param  positive-int  $chunkSize
      */

--- a/tests/Feature/ReadmeExamplesTest.php
+++ b/tests/Feature/ReadmeExamplesTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use Robertogallea\CodiceFiscale\CodiceFiscale;
+use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\PartialPerson;
+use Robertogallea\CodiceFiscale\Data\Person;
+use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Generation\Generator;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\ForeignCountry;
+use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\Municipality;
+use Robertogallea\CodiceFiscale\Matching\Matcher;
+use Robertogallea\CodiceFiscale\Omocodia\Omocodia;
+use Robertogallea\CodiceFiscale\Parsing\Parser;
+use Robertogallea\CodiceFiscale\Validation\Validator;
+
+/**
+ * Every value asserted here is the literal value transcribed into
+ * README.md's walkthrough - this test exists so that file can never
+ * silently drift from the real API's actual behavior.
+ */
+function seedRoma(): void
+{
+    Municipality::create([
+        'code' => 'H501', 'name' => 'ROMA', 'province' => 'RM',
+        'istat_code' => '058091', 'valid_from' => '1871-01-01', 'valid_to' => null,
+    ]);
+}
+
+function marioRossiReadme(): Person
+{
+    return new Person(
+        firstName: 'Mario',
+        lastName: 'Rossi',
+        birthDate: new DateTimeImmutable('1985-04-15'),
+        birthPlace: BirthPlaceCode::from('H501'),
+        gender: Gender::Male,
+    );
+}
+
+test('README: generating a code from a Person', function () {
+    $cf = (new Generator())->generate(marioRossiReadme());
+
+    expect($cf)->toBeInstanceOf(CodiceFiscale::class)
+        ->and($cf->value())->toBe('RSSMRA85D15H501T');
+});
+
+test('README: constructing a CodiceFiscale from/tryFrom a string', function () {
+    $cf = CodiceFiscale::from('RSSMRA85D15H501T');
+    expect($cf->value())->toBe('RSSMRA85D15H501T');
+
+    expect(CodiceFiscale::tryFrom('not-a-real-code'))->toBeNull();
+    expect(fn () => CodiceFiscale::from('not-a-real-code'))
+        ->toThrow(Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException::class);
+});
+
+test('README: parsing a code with the real, container-bound BirthPlaceRepository', function () {
+    seedRoma();
+    $cf = CodiceFiscale::from('RSSMRA85D15H501T');
+
+    $repository = app(BirthPlaceRepository::class);
+    $parsed = (new Parser($repository))->parse($cf);
+
+    expect($parsed->surnameCode())->toBe('RSS')
+        ->and($parsed->nameCode())->toBe('MRA')
+        ->and($parsed->gender())->toBe(Gender::Male)
+        ->and($parsed->birthDate()?->format('Y-m-d'))->toBe('1985-04-15')
+        ->and($parsed->birthPlaceCode()->value())->toBe('H501')
+        ->and($parsed->birthPlace()?->name())->toBe('ROMA')
+        ->and($parsed->isOmocodia())->toBeFalse();
+});
+
+test('README: validating a code end to end', function () {
+    seedRoma();
+    $validator = new Validator(app(BirthPlaceRepository::class));
+
+    $result = $validator->validate('RSSMRA85D15H501T');
+
+    expect($result->valid())->toBeTrue()
+        ->and($result->errors())->toBe([]);
+
+    $badResult = $validator->validate('not-a-real-code');
+    expect($badResult->valid())->toBeFalse()
+        ->and($badResult->errors())->toBe([Robertogallea\CodiceFiscale\Enums\ValidationError::InvalidFormat]);
+});
+
+test('README: matching a code against a Person/PartialPerson', function () {
+    seedRoma();
+    $cf = (new Generator())->generate(marioRossiReadme());
+    $matcher = new Matcher(new Parser(app(BirthPlaceRepository::class)));
+
+    $fullMatch = $matcher->match($cf, marioRossiReadme());
+    expect($fullMatch->matches())->toBeTrue()
+        ->and($fullMatch->skipped())->toBe([]);
+
+    $partial = $matcher->match($cf, new PartialPerson(firstName: 'Mario', gender: Gender::Female));
+    expect($partial->matches())->toBeFalse()
+        ->and($partial->mismatched())->toBe([Robertogallea\CodiceFiscale\Enums\PersonField::Gender])
+        ->and($partial->matched())->toBe([Robertogallea\CodiceFiscale\Enums\PersonField::FirstName]);
+});
+
+test('README: omocodia canonical()/variants()/level()', function () {
+    $cf = CodiceFiscale::from('RSSMRA85D15H501T');
+    $omocodia = new Omocodia();
+
+    expect($omocodia->canonical($cf)->value())->toBe('RSSMRA85D15H501T')
+        ->and($omocodia->level($cf))->toBe(0)
+        ->and(iterator_to_array($omocodia->variants($cf)))->toHaveCount(128);
+
+    $variants = iterator_to_array($omocodia->variants($cf));
+    $oneSubstitution = current(array_filter($variants, fn ($variant) => $omocodia->level($variant) === 1));
+
+    expect($oneSubstitution->isEquivalentTo($cf))->toBeTrue()
+        ->and($oneSubstitution->value())->toBe('RSSMRA85D15H50ML');
+});
+
+test('README: BirthPlaceRepository find()/existedEver(), domestic and foreign', function () {
+    seedRoma();
+    ForeignCountry::create([
+        'code' => 'Z404', 'name' => "STATI UNITI D'AMERICA", 'country_code' => 'USA',
+        'valid_from' => '1900-01-01', 'valid_to' => null,
+    ]);
+
+    $repository = app(BirthPlaceRepository::class);
+
+    $roma = $repository->find(BirthPlaceCode::from('H501'));
+    expect($roma)->toBeInstanceOf(Robertogallea\CodiceFiscale\Data\DomesticBirthPlace::class)
+        ->and($roma->name())->toBe('ROMA')
+        ->and($roma->province())->toBe('RM');
+
+    $usa = $repository->find(BirthPlaceCode::from('Z404'));
+    expect($usa)->toBeInstanceOf(Robertogallea\CodiceFiscale\Data\ForeignBirthPlace::class)
+        ->and($usa->country()->value())->toBe('USA');
+
+    expect($repository->existedEver(BirthPlaceCode::from('A999')))->toBeFalse();
+});

--- a/tests/Feature/ReadmeExamplesTest.php
+++ b/tests/Feature/ReadmeExamplesTest.php
@@ -2,15 +2,23 @@
 
 use Robertogallea\CodiceFiscale\CodiceFiscale;
 use Robertogallea\CodiceFiscale\Contracts\BirthPlaceRepository;
+use Robertogallea\CodiceFiscale\Contracts\CenturyResolver;
+use Robertogallea\CodiceFiscale\Contracts\NameNormalizer;
 use Robertogallea\CodiceFiscale\Data\BirthPlaceCode;
+use Robertogallea\CodiceFiscale\Data\DomesticBirthPlace;
+use Robertogallea\CodiceFiscale\Data\ForeignBirthPlace;
 use Robertogallea\CodiceFiscale\Data\PartialPerson;
 use Robertogallea\CodiceFiscale\Data\Person;
 use Robertogallea\CodiceFiscale\Enums\Gender;
+use Robertogallea\CodiceFiscale\Enums\PersonField;
+use Robertogallea\CodiceFiscale\Enums\ValidationError;
+use Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException;
 use Robertogallea\CodiceFiscale\Generation\Generator;
 use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\ForeignCountry;
 use Robertogallea\CodiceFiscale\Laravel\BirthPlaces\Models\Municipality;
 use Robertogallea\CodiceFiscale\Matching\Matcher;
 use Robertogallea\CodiceFiscale\Omocodia\Omocodia;
+use Robertogallea\CodiceFiscale\Parsing\Century\AgeBasedCenturyResolver;
 use Robertogallea\CodiceFiscale\Parsing\Parser;
 use Robertogallea\CodiceFiscale\Validation\Validator;
 
@@ -51,7 +59,7 @@ test('README: constructing a CodiceFiscale from/tryFrom a string', function () {
 
     expect(CodiceFiscale::tryFrom('not-a-real-code'))->toBeNull();
     expect(fn () => CodiceFiscale::from('not-a-real-code'))
-        ->toThrow(Robertogallea\CodiceFiscale\Exceptions\InvalidCodiceFiscaleException::class);
+        ->toThrow(InvalidCodiceFiscaleException::class);
 });
 
 test('README: parsing a code with the real, container-bound BirthPlaceRepository', function () {
@@ -81,7 +89,7 @@ test('README: validating a code end to end', function () {
 
     $badResult = $validator->validate('not-a-real-code');
     expect($badResult->valid())->toBeFalse()
-        ->and($badResult->errors())->toBe([Robertogallea\CodiceFiscale\Enums\ValidationError::InvalidFormat]);
+        ->and($badResult->errors())->toBe([ValidationError::InvalidFormat]);
 });
 
 test('README: matching a code against a Person/PartialPerson', function () {
@@ -95,8 +103,8 @@ test('README: matching a code against a Person/PartialPerson', function () {
 
     $partial = $matcher->match($cf, new PartialPerson(firstName: 'Mario', gender: Gender::Female));
     expect($partial->matches())->toBeFalse()
-        ->and($partial->mismatched())->toBe([Robertogallea\CodiceFiscale\Enums\PersonField::Gender])
-        ->and($partial->matched())->toBe([Robertogallea\CodiceFiscale\Enums\PersonField::FirstName]);
+        ->and($partial->mismatched())->toBe([PersonField::Gender])
+        ->and($partial->matched())->toBe([PersonField::FirstName]);
 });
 
 test('README: omocodia canonical()/variants()/level()', function () {
@@ -124,13 +132,46 @@ test('README: BirthPlaceRepository find()/existedEver(), domestic and foreign', 
     $repository = app(BirthPlaceRepository::class);
 
     $roma = $repository->find(BirthPlaceCode::from('H501'));
-    expect($roma)->toBeInstanceOf(Robertogallea\CodiceFiscale\Data\DomesticBirthPlace::class)
+    expect($roma)->toBeInstanceOf(DomesticBirthPlace::class)
         ->and($roma->name())->toBe('ROMA')
         ->and($roma->province())->toBe('RM');
 
     $usa = $repository->find(BirthPlaceCode::from('Z404'));
-    expect($usa)->toBeInstanceOf(Robertogallea\CodiceFiscale\Data\ForeignBirthPlace::class)
+    expect($usa)->toBeInstanceOf(ForeignBirthPlace::class)
         ->and($usa->country()->value())->toBe('USA');
 
     expect($repository->existedEver(BirthPlaceCode::from('A999')))->toBeFalse();
+});
+
+test('README: swapping NameNormalizer changes how Generator encodes a name', function () {
+    $reversingNormalizer = new class implements NameNormalizer {
+        public function normalize(string $name): string
+        {
+            return strtoupper(strrev($name));
+        }
+    };
+
+    $default = (new Generator())->generate(marioRossiReadme());
+    $customized = (new Generator(nameNormalizer: $reversingNormalizer))->generate(marioRossiReadme());
+
+    expect($customized->value())->not->toBe($default->value());
+});
+
+test('README: supplying a custom CenturyResolver changes which century an ambiguous two-digit year resolves to', function () {
+    $default = new AgeBasedCenturyResolver(maxAge: 120);
+
+    $always1900s = new class implements CenturyResolver {
+        public function resolve(array $possibleYears): int
+        {
+            return min($possibleYears);
+        }
+    };
+
+    // Code '02': 1902 is 124 years before 2026 (over the default's
+    // 120-year plausibility window), so the built-in default falls
+    // back to 2002 - the youngest plausible reading. A domain that
+    // knows better (e.g. "this system only has customers born after
+    // 1970... but definitely not after 2000") can override that guess.
+    expect($default->resolve([1902, 2002]))->toBe(2002)
+        ->and($always1900s->resolve([1902, 2002]))->toBe(1902);
 });


### PR DESCRIPTION
## Summary

- Rewrites `README.md` (#89, part of #75) to document the complete 3.x API end to end: the framework-agnostic core (`CodiceFiscale`, `Generator`, `Parser`, `Validator`, `Matcher`, `Omocodia`, the `BirthPlace` domain, and the swappable `NameNormalizer`/`CenturyResolver` extension points) and the Laravel integration layer (`CodiceFiscaleRule`, `CodiceFiscaleCast`, the Faker provider, `codice-fiscale:update-places`).
- Adds `UPGRADE.md`: a complete 2.x→3.x call-by-call migration table, sourced from the actual 2.x public API at tag `2.3.1` — every method on `CodiceFiscale`, every `CodiceFiscaleValidationException` constant, the city-decoder classes, `CodiceFiscaleConfig`, the pipe-delimited validation rule syntax, and the old Faker provider's parameters, each mapped to its 3.x equivalent (or explicitly marked as removed/replaced, with why).
- Every non-trivial code example in both files is transcribed from a real, passing test (`tests/Feature/ReadmeExamplesTest.php`) rather than hand-written — the generated code string, its checksum character, a real one-substitution omocodia variant, and every decoded/validated/matched value shown are the actual output of running the real API against real seeded data, not typed by hand.
- Reviewed via `/code-review` (Standards + Spec axes):
  - Standards review ran the proof-test directly and cross-checked every method signature/behavioral claim in both docs against the real source — found no factual errors, no broken internal links (including a subtle GitHub-slug case: `` `codice-fiscale:update-places` `` → `#codice-fiscaleupdate-places`, colon stripped not hyphenated), and confirmed domain vocabulary matches `CONTEXT.md`/the ADRs. One minor nit (inline fully-qualified class names instead of the file's own imports) — fixed.
  - Spec review found AC2 ("every public class/method... documented with a usage example") wasn't fully met: the spec's own user stories 10 and 14 explicitly frame `CenturyResolver` and `NameNormalizer` as swappable, user-facing extension points ("I want to supply my own `CenturyResolver`... to apply domain-specific knowledge"), not just internal `Generator`/`Parser` wiring — but neither swap was shown. Added a new "Customizing generation and parsing" section covering both (plus `BirthPlaceCode::equals()`/`CountryCode`), each backed by a new real test — including a concrete demonstration of *why* a custom `CenturyResolver` matters (a two-digit year where the 120-year default plausibility window picks the wrong century).

## Acceptance criteria

- [x] Every documented 2.x public method has a corresponding row in `UPGRADE.md` pointing at its 3.x equivalent.
- [x] Every public 3.x class/method introduced across the other tickets is documented in the README with a usage example.
- [x] The README's installation/setup section covers `codice-fiscale:update-places` and the dedicated-SQLite-connection behaviour.

## Test plan

- [x] `composer test` — 207 tests passing, 976 assertions
- [x] `composer phpstan` — clean at level `max`
- [x] `php-cs-fixer` — clean, no files needed fixing
- [x] `tests/Feature/ReadmeExamplesTest.php`: every non-trivial README example (generation, parsing, validation, matching, omocodia, the birthplace repository, and the two new swappable-collaborator examples) runs for real and asserts the exact literal values shown in the docs